### PR TITLE
[APPC-718/APPC-719] - Change event name and add new field to all events

### DIFF
--- a/app/src/main/java/com/asfoundation/wallet/analytics/FacebookEventLogger.java
+++ b/app/src/main/java/com/asfoundation/wallet/analytics/FacebookEventLogger.java
@@ -23,7 +23,7 @@ public class FacebookEventLogger implements EventLogger {
       if (entry.getValue()
           .getClass()
           .isInstance(new HashMap())) {
-        flatten((HashMap) entry.getValue());
+        bundle.putAll(flatten((HashMap) entry.getValue()));
       } else {
         bundle.putString(entry.getKey(), entry.getValue()
             .toString());

--- a/app/src/main/java/com/asfoundation/wallet/billing/analytics/BillingAnalytics.java
+++ b/app/src/main/java/com/asfoundation/wallet/billing/analytics/BillingAnalytics.java
@@ -7,7 +7,7 @@ import cm.aptoide.analytics.AnalyticsManager;
 public class BillingAnalytics implements EventSender {
   private static final String WALLET = "WALLET";
   public static final String PURCHASE_DETAILS = "PURCHASE_DETAILS";
-  public static final String CREDIT_CARD_DETAILS = "CREDIT_CARD_DETAILS";
+  public static final String PAYMENT_METHOD_DETAILS = "PAYMENT_METHOD_DETAILS";
   public static final String PAYMENT = "PAYMENT";
   private static final String EVENT_PACKAGE_NAME= "package_name";
   private static final String EVENT_SKU = "sku";
@@ -41,7 +41,8 @@ public class BillingAnalytics implements EventSender {
   }
 
   @Override
-  public void sendCreditCardDetailsEvent(String packageName, String skuDetails, String value) {
+  public void sendPaymentMethodDetailsEvent(String packageName, String skuDetails, String value,
+      String purchaseDetails) {
     Map<String, Object> map = new HashMap<>();
     Map<String, Object> map2 = new HashMap<>();
 
@@ -50,8 +51,9 @@ public class BillingAnalytics implements EventSender {
     map2.put(EVENT_VALUE, value);
 
     map.put(EVENT_PURCHASE, map2);
+    map.put(EVENT_PAYMENT_METHOD, purchaseDetails);
 
-    analytics.logEvent(map, CREDIT_CARD_DETAILS, AnalyticsManager.Action.CLICK, WALLET);
+    analytics.logEvent(map, PAYMENT_METHOD_DETAILS, AnalyticsManager.Action.CLICK, WALLET);
   }
 
   @Override public void sendPaymentEvent(String packageName, String skuDetails, String value, String purchaseDetail) {

--- a/app/src/main/java/com/asfoundation/wallet/billing/analytics/BillingAnalytics.java
+++ b/app/src/main/java/com/asfoundation/wallet/billing/analytics/BillingAnalytics.java
@@ -9,10 +9,11 @@ public class BillingAnalytics implements EventSender {
   public static final String PURCHASE_DETAILS = "PURCHASE_DETAILS";
   public static final String PAYMENT_METHOD_DETAILS = "PAYMENT_METHOD_DETAILS";
   public static final String PAYMENT = "PAYMENT";
-  private static final String EVENT_PACKAGE_NAME= "package_name";
+  private static final String EVENT_PACKAGE_NAME = "package_name";
   private static final String EVENT_SKU = "sku";
   private static final String EVENT_VALUE = "value";
-  private static final String EVENT_PURCHASE= "purchase";
+  private static final String EVENT_PURCHASE = "purchase";
+  private static final String EVENT_TRANSACTION_TYPE = "transaction_type";
   private static final String EVENT_PAYMENT_METHOD = "payment_method";
   public static final String PAYMENT_METHOD_APPC = "APPC";
   public static final String PAYMENT_METHOD_CC = "CREDIT_CARD";
@@ -26,23 +27,7 @@ public class BillingAnalytics implements EventSender {
 
   @Override
   public void sendPurchaseDetailsEvent(String packageName, String skuDetails, String value,
-      String purchaseDetail) {
-    Map<String, Object> map = new HashMap<>();
-    Map<String, Object> map2 = new HashMap<>();
-
-    map2.put(EVENT_PACKAGE_NAME, packageName);
-    map2.put(EVENT_SKU, skuDetails);
-    map2.put(EVENT_VALUE, value);
-
-    map.put(EVENT_PURCHASE, map2);
-    map.put(EVENT_PAYMENT_METHOD, purchaseDetail);
-
-    analytics.logEvent(map, PURCHASE_DETAILS, AnalyticsManager.Action.CLICK, WALLET);
-  }
-
-  @Override
-  public void sendPaymentMethodDetailsEvent(String packageName, String skuDetails, String value,
-      String purchaseDetails) {
+      String purchaseDetails, String transactionType) {
     Map<String, Object> map = new HashMap<>();
     Map<String, Object> map2 = new HashMap<>();
 
@@ -52,11 +37,14 @@ public class BillingAnalytics implements EventSender {
 
     map.put(EVENT_PURCHASE, map2);
     map.put(EVENT_PAYMENT_METHOD, purchaseDetails);
+    map.put(EVENT_TRANSACTION_TYPE, transactionType);
 
-    analytics.logEvent(map, PAYMENT_METHOD_DETAILS, AnalyticsManager.Action.CLICK, WALLET);
+    analytics.logEvent(map, PURCHASE_DETAILS, AnalyticsManager.Action.CLICK, WALLET);
   }
 
-  @Override public void sendPaymentEvent(String packageName, String skuDetails, String value, String purchaseDetail) {
+  @Override
+  public void sendPaymentMethodDetailsEvent(String packageName, String skuDetails, String value,
+      String purchaseDetails, String transactionType) {
     Map<String, Object> map = new HashMap<>();
     Map<String, Object> map2 = new HashMap<>();
 
@@ -65,7 +53,25 @@ public class BillingAnalytics implements EventSender {
     map2.put(EVENT_VALUE, value);
 
     map.put(EVENT_PURCHASE, map2);
-    map.put(EVENT_PAYMENT_METHOD, purchaseDetail);
+    map.put(EVENT_PAYMENT_METHOD, purchaseDetails);
+    map.put(EVENT_TRANSACTION_TYPE, transactionType);
+
+    analytics.logEvent(map, PAYMENT_METHOD_DETAILS, AnalyticsManager.Action.CLICK, WALLET);
+  }
+
+  @Override
+  public void sendPaymentEvent(String packageName, String skuDetails, String value,
+      String purchaseDetails, String transactionType) {
+    Map<String, Object> map = new HashMap<>();
+    Map<String, Object> map2 = new HashMap<>();
+
+    map2.put(EVENT_PACKAGE_NAME, packageName);
+    map2.put(EVENT_SKU, skuDetails);
+    map2.put(EVENT_VALUE, value);
+
+    map.put(EVENT_PURCHASE, map2);
+    map.put(EVENT_PAYMENT_METHOD, purchaseDetails);
+    map.put(EVENT_TRANSACTION_TYPE, transactionType);
 
     analytics.logEvent(map, PAYMENT, AnalyticsManager.Action.IMPRESSION, WALLET);
   }

--- a/app/src/main/java/com/asfoundation/wallet/billing/analytics/EventSender.java
+++ b/app/src/main/java/com/asfoundation/wallet/billing/analytics/EventSender.java
@@ -3,9 +3,9 @@ package com.asfoundation.wallet.billing.analytics;
 
 public interface EventSender {
 
-    void sendPurchaseDetailsEvent(String packageName, String skuDetails, String value, String purchaseDetail);
+    void sendPurchaseDetailsEvent(String packageName, String skuDetails, String value, String purchaseDetails, String transactionType);
 
-    void sendPaymentMethodDetailsEvent(String packageName, String skuDetails, String value, String purchaseDetails);
+    void sendPaymentMethodDetailsEvent(String packageName, String skuDetails, String value, String purchaseDetails, String transactionType);
 
-    void sendPaymentEvent(String packageName, String skuDetails, String value, String paymentDetails);
+    void sendPaymentEvent(String packageName, String skuDetails, String value, String purchaseDetails, String transactionType);
 }

--- a/app/src/main/java/com/asfoundation/wallet/billing/analytics/EventSender.java
+++ b/app/src/main/java/com/asfoundation/wallet/billing/analytics/EventSender.java
@@ -5,7 +5,7 @@ public interface EventSender {
 
     void sendPurchaseDetailsEvent(String packageName, String skuDetails, String value, String purchaseDetail);
 
-    void sendCreditCardDetailsEvent(String packageName, String skuDetails, String value);
+    void sendPaymentMethodDetailsEvent(String packageName, String skuDetails, String value, String purchaseDetails);
 
     void sendPaymentEvent(String packageName, String skuDetails, String value, String paymentDetails);
 }

--- a/app/src/main/java/com/asfoundation/wallet/di/ToolsModule.java
+++ b/app/src/main/java/com/asfoundation/wallet/di/ToolsModule.java
@@ -733,7 +733,7 @@ import static com.asfoundation.wallet.service.AppsApi.API_BASE_URL;
   @Singleton @Provides @Named("bi_event_list") List<String> provideBiEventList() {
     List<String> list = new ArrayList<>();
     list.add(BillingAnalytics.PURCHASE_DETAILS);
-    list.add(BillingAnalytics.CREDIT_CARD_DETAILS);
+    list.add(BillingAnalytics.PAYMENT_METHOD_DETAILS);
     list.add(BillingAnalytics.PAYMENT);
     return list;
   }
@@ -741,7 +741,7 @@ import static com.asfoundation.wallet.service.AppsApi.API_BASE_URL;
   @Singleton @Provides @Named("facebook_event_list") List<String> provideFacebookEventList() {
     List<String> list = new ArrayList<>();
     list.add(BillingAnalytics.PURCHASE_DETAILS);
-    list.add(BillingAnalytics.CREDIT_CARD_DETAILS);
+    list.add(BillingAnalytics.PAYMENT_METHOD_DETAILS);
     list.add(BillingAnalytics.PAYMENT);
     return list;
   }

--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/AppcoinsRewardsBuyPresenter.java
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/AppcoinsRewardsBuyPresenter.java
@@ -4,7 +4,6 @@ import com.appcoins.wallet.appcoins.rewards.Transaction;
 import com.appcoins.wallet.appcoins.rewards.TransactionIdRepository;
 import com.appcoins.wallet.billing.repository.entity.TransactionData;
 import com.asfoundation.wallet.billing.analytics.BillingAnalytics;
-import com.asfoundation.wallet.entity.TransactionBuilder;
 import com.asfoundation.wallet.util.TransferParser;
 import io.reactivex.Completable;
 import io.reactivex.Scheduler;
@@ -141,19 +140,16 @@ public class AppcoinsRewardsBuyPresenter {
   }
 
   public void sendPurchaseDetails(String purchaseDetails) {
-    TransactionBuilder transactionBuilder = inAppPurchaseInteractor.parseTransaction(uri, isBds)
-        .blockingGet();
-    analytics.sendPurchaseDetailsEvent(packageName, transactionBuilder.getSkuId(),
-        transactionBuilder.amount()
-            .toString(), purchaseDetails, transactionBuilder.getType());
+    inAppPurchaseInteractor.parseTransaction(uri, isBds)
+        .subscribe(transactionBuilder -> analytics.sendPurchaseDetailsEvent(packageName,
+            transactionBuilder.getSkuId(), transactionBuilder.amount()
+                .toString(), purchaseDetails, transactionBuilder.getType()));
   }
 
   public void sendPaymentEvent(String purchaseDetails) {
-    TransactionBuilder transactionBuilder =
-        inAppPurchaseInteractor.parseTransaction(uri, isBds)
-            .blockingGet();
-    analytics.sendPaymentEvent(packageName, transactionBuilder.getSkuId(),
-        transactionBuilder.amount()
-            .toString(), purchaseDetails, transactionBuilder.getType());
+    inAppPurchaseInteractor.parseTransaction(uri, isBds)
+        .subscribe(transactionBuilder -> analytics.sendPaymentEvent(packageName,
+            transactionBuilder.getSkuId(), transactionBuilder.amount()
+                .toString(), purchaseDetails, transactionBuilder.getType()));
   }
 }

--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/AppcoinsRewardsBuyPresenter.java
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/AppcoinsRewardsBuyPresenter.java
@@ -145,7 +145,7 @@ public class AppcoinsRewardsBuyPresenter {
         .blockingGet();
     analytics.sendPurchaseDetailsEvent(packageName, transactionBuilder.getSkuId(),
         transactionBuilder.amount()
-            .toString(), purchaseDetails);
+            .toString(), purchaseDetails, transactionBuilder.getType());
   }
 
   public void sendPaymentEvent(String purchaseDetails) {
@@ -154,6 +154,6 @@ public class AppcoinsRewardsBuyPresenter {
             .blockingGet();
     analytics.sendPaymentEvent(packageName, transactionBuilder.getSkuId(),
         transactionBuilder.amount()
-            .toString(), purchaseDetails);
+            .toString(), purchaseDetails, transactionBuilder.getType());
   }
 }

--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/CreditCardAuthorizationFragment.java
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/CreditCardAuthorizationFragment.java
@@ -321,7 +321,7 @@ public class CreditCardAuthorizationFragment extends DaggerFragment
   }
 
   @Override public void close(Bundle bundle) {
-    presenter.sendCCDetailsEvent();
+    presenter.sendPaymentMethodDetailsEvent();
     iabView.close(bundle);
   }
 
@@ -349,7 +349,7 @@ public class CreditCardAuthorizationFragment extends DaggerFragment
         .getParent()
         .getParent()
         .getParent()).setPadding(24, 0, 0, 0);
-    presenter.sendCCDetailsEvent();
+    presenter.sendPaymentMethodDetailsEvent();
   }
 
   private PaymentDetails getPaymentDetails(String publicKey, String generationTime) {

--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/CreditCardAuthorizationFragment.java
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/CreditCardAuthorizationFragment.java
@@ -321,7 +321,6 @@ public class CreditCardAuthorizationFragment extends DaggerFragment
   }
 
   @Override public void close(Bundle bundle) {
-    presenter.sendPaymentMethodDetailsEvent();
     iabView.close(bundle);
   }
 

--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/CreditCardAuthorizationPresenter.java
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/CreditCardAuthorizationPresenter.java
@@ -9,6 +9,7 @@ import com.asfoundation.wallet.billing.CreditCardBilling;
 import com.asfoundation.wallet.billing.analytics.BillingAnalytics;
 import com.asfoundation.wallet.billing.authorization.AdyenAuthorization;
 import com.asfoundation.wallet.billing.payment.Adyen;
+import com.asfoundation.wallet.entity.TransactionBuilder;
 import com.asfoundation.wallet.interact.FindDefaultWalletInteract;
 import io.reactivex.Completable;
 import io.reactivex.Flowable;
@@ -54,6 +55,7 @@ public class CreditCardAuthorizationPresenter {
   private CreditCardAuthorizationView view;
   private FindDefaultWalletInteract defaultWalletInteract;
   private BillingAnalytics analytics;
+  private final Single<TransactionBuilder> transactionBuilder;
 
   public CreditCardAuthorizationPresenter(CreditCardAuthorizationView view, String appPackage,
       FindDefaultWalletInteract defaultWalletInteract, Scheduler viewScheduler,
@@ -81,6 +83,7 @@ public class CreditCardAuthorizationPresenter {
     this.amount = amount;
     this.currency = currency;
     this.analytics = analytics;
+    this.transactionBuilder = inAppPurchaseInteractor.parseTransaction(transactionData, true);
   }
 
   public void present() {
@@ -149,18 +152,17 @@ public class CreditCardAuthorizationPresenter {
 
   private void onViewCreatedCreatePayment() {
     disposables.add(Completable.fromAction(() -> view.showLoading())
-        .andThen(inAppPurchaseInteractor.parseTransaction(transactionData, true)
-            .flatMapCompletable(
-                transaction -> creditCardBilling.getAuthorization(transaction.getSkuId(),
-                    transaction.toAddress(), developerPayload, origin, convertAmount(currency),
-                    currency, type)
-                    .observeOn(viewScheduler)
-                    .filter(payment -> payment.isPendingAuthorization())
-                    .firstOrError()
-                    .map(payment -> payment)
-                    .flatMapCompletable(
-                        authorization -> adyen.createPayment(authorization.getSession()))
-                    .observeOn(viewScheduler)))
+        .andThen(transactionBuilder.flatMapCompletable(
+            transaction -> creditCardBilling.getAuthorization(transaction.getSkuId(),
+                transaction.toAddress(), developerPayload, origin, convertAmount(currency),
+                currency, type)
+                .observeOn(viewScheduler)
+                .filter(payment -> payment.isPendingAuthorization())
+                .firstOrError()
+                .map(payment -> payment)
+                .flatMapCompletable(
+                    authorization -> adyen.createPayment(authorization.getSession()))
+                .observeOn(viewScheduler)))
         .subscribe(() -> {
         }, throwable -> showError(throwable)));
   }
@@ -182,8 +184,8 @@ public class CreditCardAuthorizationPresenter {
   }
 
   private void onViewCreatedCheckAuthorizationActive() {
-    disposables.add(inAppPurchaseInteractor.parseTransaction(transactionData, true)
-        .flatMap(transaction -> creditCardBilling.getAuthorization(transaction.getSkuId(),
+    disposables.add(transactionBuilder.flatMap(
+        transaction -> creditCardBilling.getAuthorization(transaction.getSkuId(),
             transaction.toAddress(), developerPayload, origin, convertAmount(currency), currency,
             type)
             .filter(payment -> payment.isCompleted())
@@ -228,8 +230,8 @@ public class CreditCardAuthorizationPresenter {
   }
 
   private void onViewCreatedCheckAuthorizationFailed() {
-    disposables.add(inAppPurchaseInteractor.parseTransaction(transactionData, true)
-        .flatMap(transaction -> creditCardBilling.getAuthorization(transaction.getSkuId(),
+    disposables.add(transactionBuilder.flatMap(
+        transaction -> creditCardBilling.getAuthorization(transaction.getSkuId(),
             transaction.toAddress(), developerPayload, origin, convertAmount(currency), currency,
             type)
             .filter(payment -> payment.isFailed())
@@ -245,8 +247,8 @@ public class CreditCardAuthorizationPresenter {
   }
 
   private void onViewCreatedCheckAuthorizationProcessing() {
-    disposables.add(inAppPurchaseInteractor.parseTransaction(transactionData, true)
-        .flatMapObservable(transaction -> creditCardBilling.getAuthorization(transaction.getSkuId(),
+    disposables.add(transactionBuilder.flatMapObservable(
+        transaction -> creditCardBilling.getAuthorization(transaction.getSkuId(),
             transaction.toAddress(), developerPayload, origin, convertAmount(currency), currency,
             type)
             .filter(payment -> payment.isProcessing())
@@ -339,16 +341,16 @@ public class CreditCardAuthorizationPresenter {
   }
 
   public void sendPaymentMethodDetailsEvent() {
-    inAppPurchaseInteractor.parseTransaction(transactionData, true)
-        .subscribe(transactionBuilder -> analytics.sendPaymentMethodDetailsEvent(appPackage,
+    disposables.add(transactionBuilder.subscribe(
+        transactionBuilder -> analytics.sendPaymentMethodDetailsEvent(appPackage,
             transactionBuilder.getSkuId(), transactionBuilder.amount()
-                .toString(), PAYMENT_METHOD_CC, transactionBuilder.getType()));
+                .toString(), PAYMENT_METHOD_CC, transactionBuilder.getType())));
   }
 
   public void sendPaymentEvent() {
-    inAppPurchaseInteractor.parseTransaction(transactionData, true)
-        .subscribe(transactionBuilder -> analytics.sendPaymentEvent(appPackage,
-            transactionBuilder.getSkuId(), transactionBuilder.amount()
-                .toString(), PAYMENT_METHOD_CC, transactionBuilder.getType()));
+    disposables.add(transactionBuilder.subscribe(
+        transactionBuilder -> analytics.sendPaymentEvent(appPackage, transactionBuilder.getSkuId(),
+            transactionBuilder.amount()
+                .toString(), PAYMENT_METHOD_CC, transactionBuilder.getType())));
   }
 }

--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/CreditCardAuthorizationPresenter.java
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/CreditCardAuthorizationPresenter.java
@@ -9,6 +9,7 @@ import com.asfoundation.wallet.billing.CreditCardBilling;
 import com.asfoundation.wallet.billing.analytics.BillingAnalytics;
 import com.asfoundation.wallet.billing.authorization.AdyenAuthorization;
 import com.asfoundation.wallet.billing.payment.Adyen;
+import com.asfoundation.wallet.entity.TransactionBuilder;
 import com.asfoundation.wallet.interact.FindDefaultWalletInteract;
 import io.reactivex.Completable;
 import io.reactivex.Flowable;
@@ -191,7 +192,7 @@ public class CreditCardAuthorizationPresenter {
             .flatMap(adyenAuthorization -> buildBundle(billing))
             .observeOn(viewScheduler)
             .doOnSuccess(bundle -> {
-              sendPaymentEvent(PAYMENT_METHOD_CC);
+              sendPaymentEvent();
               navigator.popView(bundle);
             })
             .doOnSuccess(__ -> view.showSuccess()))
@@ -338,11 +339,21 @@ public class CreditCardAuthorizationPresenter {
     disposables.clear();
   }
 
-  public void sendCCDetailsEvent() {
-    analytics.sendCreditCardDetailsEvent(appPackage, skuId, amount);
+  public void sendPaymentMethodDetailsEvent() {
+    TransactionBuilder transactionBuilder =
+        inAppPurchaseInteractor.parseTransaction(transactionData, true)
+            .blockingGet();
+    analytics.sendPaymentMethodDetailsEvent(appPackage, transactionBuilder.getSkuId(),
+        transactionBuilder.amount()
+            .toString(), PAYMENT_METHOD_CC);
   }
 
-  public void sendPaymentEvent(String purchaseDetails) {
-    analytics.sendPaymentEvent(appPackage, skuId, amount, purchaseDetails);
+  public void sendPaymentEvent() {
+    TransactionBuilder transactionBuilder =
+        inAppPurchaseInteractor.parseTransaction(transactionData, true)
+            .blockingGet();
+    analytics.sendPaymentEvent(appPackage, transactionBuilder.getSkuId(),
+        transactionBuilder.amount()
+            .toString(), PAYMENT_METHOD_CC);
   }
 }

--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/CreditCardAuthorizationPresenter.java
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/CreditCardAuthorizationPresenter.java
@@ -345,7 +345,7 @@ public class CreditCardAuthorizationPresenter {
             .blockingGet();
     analytics.sendPaymentMethodDetailsEvent(appPackage, transactionBuilder.getSkuId(),
         transactionBuilder.amount()
-            .toString(), PAYMENT_METHOD_CC);
+            .toString(), PAYMENT_METHOD_CC, transactionBuilder.getType());
   }
 
   public void sendPaymentEvent() {
@@ -354,6 +354,6 @@ public class CreditCardAuthorizationPresenter {
             .blockingGet();
     analytics.sendPaymentEvent(appPackage, transactionBuilder.getSkuId(),
         transactionBuilder.amount()
-            .toString(), PAYMENT_METHOD_CC);
+            .toString(), PAYMENT_METHOD_CC, transactionBuilder.getType());
   }
 }

--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/CreditCardAuthorizationPresenter.java
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/CreditCardAuthorizationPresenter.java
@@ -9,7 +9,6 @@ import com.asfoundation.wallet.billing.CreditCardBilling;
 import com.asfoundation.wallet.billing.analytics.BillingAnalytics;
 import com.asfoundation.wallet.billing.authorization.AdyenAuthorization;
 import com.asfoundation.wallet.billing.payment.Adyen;
-import com.asfoundation.wallet.entity.TransactionBuilder;
 import com.asfoundation.wallet.interact.FindDefaultWalletInteract;
 import io.reactivex.Completable;
 import io.reactivex.Flowable;
@@ -340,20 +339,16 @@ public class CreditCardAuthorizationPresenter {
   }
 
   public void sendPaymentMethodDetailsEvent() {
-    TransactionBuilder transactionBuilder =
-        inAppPurchaseInteractor.parseTransaction(transactionData, true)
-            .blockingGet();
-    analytics.sendPaymentMethodDetailsEvent(appPackage, transactionBuilder.getSkuId(),
-        transactionBuilder.amount()
-            .toString(), PAYMENT_METHOD_CC, transactionBuilder.getType());
+    inAppPurchaseInteractor.parseTransaction(transactionData, true)
+        .subscribe(transactionBuilder -> analytics.sendPaymentMethodDetailsEvent(appPackage,
+            transactionBuilder.getSkuId(), transactionBuilder.amount()
+                .toString(), PAYMENT_METHOD_CC, transactionBuilder.getType()));
   }
 
   public void sendPaymentEvent() {
-    TransactionBuilder transactionBuilder =
-        inAppPurchaseInteractor.parseTransaction(transactionData, true)
-            .blockingGet();
-    analytics.sendPaymentEvent(appPackage, transactionBuilder.getSkuId(),
-        transactionBuilder.amount()
-            .toString(), PAYMENT_METHOD_CC, transactionBuilder.getType());
+    inAppPurchaseInteractor.parseTransaction(transactionData, true)
+        .subscribe(transactionBuilder -> analytics.sendPaymentEvent(appPackage,
+            transactionBuilder.getSkuId(), transactionBuilder.amount()
+                .toString(), PAYMENT_METHOD_CC, transactionBuilder.getType()));
   }
 }

--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/ExpressCheckoutBuyPresenter.java
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/ExpressCheckoutBuyPresenter.java
@@ -167,7 +167,7 @@ public class ExpressCheckoutBuyPresenter {
             .blockingGet();
     analytics.sendPurchaseDetailsEvent(appPackage, transactionBuilder.getSkuId(),
         transactionBuilder.amount()
-            .toString(), purchaseDetails);
+            .toString(), purchaseDetails, transactionBuilder.getType());
   }
 
   public boolean isBds() {

--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/ExpressCheckoutBuyPresenter.java
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/ExpressCheckoutBuyPresenter.java
@@ -6,9 +6,7 @@ import com.appcoins.wallet.bdsbilling.repository.entity.Purchase;
 import com.appcoins.wallet.bdsbilling.repository.entity.Transaction;
 import com.appcoins.wallet.billing.BillingMessagesMapper;
 import com.asfoundation.wallet.billing.analytics.BillingAnalytics;
-import com.asfoundation.wallet.entity.TransactionBuilder;
 import com.appcoins.wallet.billing.repository.entity.TransactionData;
-import com.asfoundation.wallet.billing.analytics.BillingAnalytics;
 import com.asfoundation.wallet.repository.BdsPendingTransactionService;
 import io.reactivex.Completable;
 import io.reactivex.Observable;
@@ -162,12 +160,10 @@ public class ExpressCheckoutBuyPresenter {
   }
 
   public void sendPurchaseDetails(String purchaseDetails) {
-    TransactionBuilder transactionBuilder =
-        inAppPurchaseInteractor.parseTransaction(uri, isBds)
-            .blockingGet();
-    analytics.sendPurchaseDetailsEvent(appPackage, transactionBuilder.getSkuId(),
-        transactionBuilder.amount()
-            .toString(), purchaseDetails, transactionBuilder.getType());
+    inAppPurchaseInteractor.parseTransaction(uri, isBds)
+        .subscribe(transactionBuilder -> analytics.sendPurchaseDetailsEvent(appPackage,
+            transactionBuilder.getSkuId(), transactionBuilder.amount()
+                .toString(), purchaseDetails, transactionBuilder.getType()));
   }
 
   public boolean isBds() {

--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/OnChainBuyPresenter.java
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/OnChainBuyPresenter.java
@@ -5,9 +5,11 @@ import android.util.Log;
 import com.appcoins.wallet.billing.BillingMessagesMapper;
 import com.appcoins.wallet.billing.repository.entity.TransactionData.TransactionType;
 import com.asfoundation.wallet.billing.analytics.BillingAnalytics;
+import com.asfoundation.wallet.entity.TransactionBuilder;
 import com.asfoundation.wallet.util.UnknownTokenException;
 import io.reactivex.Completable;
 import io.reactivex.Scheduler;
+import io.reactivex.Single;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.CompositeDisposable;
 import io.reactivex.schedulers.Schedulers;
@@ -32,6 +34,7 @@ public class OnChainBuyPresenter {
   private BillingAnalytics analytics;
   private final String appPackage;
   private final String uriString;
+  private final Single<TransactionBuilder> transactionBuilder;
 
   public OnChainBuyPresenter(OnChainBuyView view, InAppPurchaseInteractor inAppPurchaseInteractor,
       Scheduler viewScheduler, CompositeDisposable disposables,
@@ -47,6 +50,7 @@ public class OnChainBuyPresenter {
     this.analytics = analytics;
     this.appPackage = appPackage;
     this.uriString = uriString;
+    this.transactionBuilder = inAppPurchaseInteractor.parseTransaction(uriString, isBds);
   }
 
   public void present(String uriString, String appPackage, String productName, BigDecimal amount,
@@ -255,22 +259,23 @@ public class OnChainBuyPresenter {
   }
 
   private void setup(BigDecimal amount, String type) {
-    view.setup(productName, TransactionType.DONATION.name().equalsIgnoreCase(type));
+    view.setup(productName, TransactionType.DONATION.name()
+        .equalsIgnoreCase(type));
     view.showRaidenChannelValues(inAppPurchaseInteractor.getTopUpChannelSuggestionValues(amount));
   }
 
   public void sendPurchaseDetails(String purchaseDetails) {
-    inAppPurchaseInteractor.parseTransaction(uriString, isBds)
-        .subscribe(transactionBuilder -> analytics.sendPurchaseDetailsEvent(appPackage,
+    disposables.add(transactionBuilder.subscribe(
+        transactionBuilder -> analytics.sendPurchaseDetailsEvent(appPackage,
             transactionBuilder.getSkuId(), transactionBuilder.amount()
-                .toString(), purchaseDetails, transactionBuilder.getType()));
+                .toString(), purchaseDetails, transactionBuilder.getType())));
   }
 
   public void sendPaymentEvent(String purchaseDetails) {
-    inAppPurchaseInteractor.parseTransaction(uriString, isBds)
-        .subscribe(transactionBuilder -> analytics.sendPaymentEvent(appPackage,
-            transactionBuilder.getSkuId(), transactionBuilder.amount()
-                .toString(), purchaseDetails, transactionBuilder.getType()));
+    disposables.add(transactionBuilder.subscribe(
+        transactionBuilder -> analytics.sendPaymentEvent(appPackage, transactionBuilder.getSkuId(),
+            transactionBuilder.amount()
+                .toString(), purchaseDetails, transactionBuilder.getType())));
   }
 
   public static class BuyData {

--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/OnChainBuyPresenter.java
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/OnChainBuyPresenter.java
@@ -5,7 +5,6 @@ import android.util.Log;
 import com.appcoins.wallet.billing.BillingMessagesMapper;
 import com.appcoins.wallet.billing.repository.entity.TransactionData.TransactionType;
 import com.asfoundation.wallet.billing.analytics.BillingAnalytics;
-import com.asfoundation.wallet.entity.TransactionBuilder;
 import com.asfoundation.wallet.util.UnknownTokenException;
 import io.reactivex.Completable;
 import io.reactivex.Scheduler;
@@ -37,7 +36,7 @@ public class OnChainBuyPresenter {
   public OnChainBuyPresenter(OnChainBuyView view, InAppPurchaseInteractor inAppPurchaseInteractor,
       Scheduler viewScheduler, CompositeDisposable disposables,
       BillingMessagesMapper billingMessagesMapper, boolean isBds, String productName,
-       BillingAnalytics analytics, String appPackage, String uriString) {
+      BillingAnalytics analytics, String appPackage, String uriString) {
     this.view = view;
     this.inAppPurchaseInteractor = inAppPurchaseInteractor;
     this.viewScheduler = viewScheduler;
@@ -261,21 +260,17 @@ public class OnChainBuyPresenter {
   }
 
   public void sendPurchaseDetails(String purchaseDetails) {
-    TransactionBuilder transactionBuilder =
-        inAppPurchaseInteractor.parseTransaction(uriString, isBds)
-            .blockingGet();
-    analytics.sendPurchaseDetailsEvent(appPackage, transactionBuilder.getSkuId(),
-        transactionBuilder.amount()
-            .toString(), purchaseDetails, transactionBuilder.getType());
+    inAppPurchaseInteractor.parseTransaction(uriString, isBds)
+        .subscribe(transactionBuilder -> analytics.sendPurchaseDetailsEvent(appPackage,
+            transactionBuilder.getSkuId(), transactionBuilder.amount()
+                .toString(), purchaseDetails, transactionBuilder.getType()));
   }
 
   public void sendPaymentEvent(String purchaseDetails) {
-    TransactionBuilder transactionBuilder =
-        inAppPurchaseInteractor.parseTransaction(uriString, isBds)
-            .blockingGet();
-    analytics.sendPaymentEvent(appPackage, transactionBuilder.getSkuId(),
-        transactionBuilder.amount()
-            .toString(), purchaseDetails, transactionBuilder.getType());
+    inAppPurchaseInteractor.parseTransaction(uriString, isBds)
+        .subscribe(transactionBuilder -> analytics.sendPaymentEvent(appPackage,
+            transactionBuilder.getSkuId(), transactionBuilder.amount()
+                .toString(), purchaseDetails, transactionBuilder.getType()));
   }
 
   public static class BuyData {

--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/OnChainBuyPresenter.java
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/OnChainBuyPresenter.java
@@ -266,7 +266,7 @@ public class OnChainBuyPresenter {
             .blockingGet();
     analytics.sendPurchaseDetailsEvent(appPackage, transactionBuilder.getSkuId(),
         transactionBuilder.amount()
-            .toString(), purchaseDetails);
+            .toString(), purchaseDetails, transactionBuilder.getType());
   }
 
   public void sendPaymentEvent(String purchaseDetails) {
@@ -275,7 +275,7 @@ public class OnChainBuyPresenter {
             .blockingGet();
     analytics.sendPaymentEvent(appPackage, transactionBuilder.getSkuId(),
         transactionBuilder.amount()
-            .toString(), purchaseDetails);
+            .toString(), purchaseDetails, transactionBuilder.getType());
   }
 
   public static class BuyData {


### PR DESCRIPTION
1 - Add "transaction_type" field to all Analytics Events;
2 - Change CREDIT_CARD_DETAILS name to PAYMENT_METHOD_DETAILS;
3 - (bugfix) Create transactionBuilder on ExpressCheckoutBuyPresenter, CreditCardAuthorizationPresenter, OnChainBuyPresenter and AppcoinsRewardsBuyPresenter to reduce the amount of times parseTransaction() is done.