### PR TITLE
[bugfix/APPC-735] - Revenue event currency conversion

### DIFF
--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/AppcoinsRewardsBuyFragment.java
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/AppcoinsRewardsBuyFragment.java
@@ -119,7 +119,7 @@ public class AppcoinsRewardsBuyFragment extends DaggerFragment implements Appcoi
         new AppcoinsRewardsBuyPresenter(this, rewardsManager, AndroidSchedulers.mainThread(),
             new CompositeDisposable(), amount, BuildConfig.DEFAULT_STORE_ADDRESS,
             BuildConfig.DEFAULT_OEM_ADDRESS, uri, callerPackageName, transferParser,
-            getProductName(), isBds, analytics, transactionBuilder);
+            getProductName(), isBds, analytics, transactionBuilder, inAppPurchaseInteractor);
 
     Single.defer(() -> Single.just(callerPackageName))
         .observeOn(Schedulers.io())

--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/AppcoinsRewardsBuyPresenter.java
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/AppcoinsRewardsBuyPresenter.java
@@ -11,6 +11,8 @@ import io.reactivex.disposables.CompositeDisposable;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 
+import static com.asfoundation.wallet.analytics.FacebookEventLogger.EVENT_REVENUE_CURRENCY;
+
 public class AppcoinsRewardsBuyPresenter {
   private final AppcoinsRewardsBuyView view;
   private final RewardsManager rewardsManager;
@@ -26,12 +28,13 @@ public class AppcoinsRewardsBuyPresenter {
   private final boolean isBds;
   private final BillingAnalytics analytics;
   private final TransactionBuilder transactionBuilder;
+  private final InAppPurchaseInteractor inAppPurchaseInteractor;
 
   public AppcoinsRewardsBuyPresenter(AppcoinsRewardsBuyView view, RewardsManager rewardsManager,
       Scheduler scheduler, CompositeDisposable disposables, BigDecimal amount, String storeAddress,
       String oemAddress, String uri, String packageName, TransferParser transferParser,
       String productName, boolean isBds, BillingAnalytics analytics,
-      TransactionBuilder transactionBuilder) {
+      TransactionBuilder transactionBuilder, InAppPurchaseInteractor inAppPurchaseInteractor) {
     this.view = view;
     this.rewardsManager = rewardsManager;
     this.scheduler = scheduler;
@@ -46,6 +49,7 @@ public class AppcoinsRewardsBuyPresenter {
     this.isBds = isBds;
     this.analytics = analytics;
     this.transactionBuilder = transactionBuilder;
+    this.inAppPurchaseInteractor = inAppPurchaseInteractor;
   }
 
   public void present() {
@@ -154,7 +158,11 @@ public class AppcoinsRewardsBuyPresenter {
   }
 
   public void sendRevenueEvent() {
-    analytics.sendRevenueEvent(transactionBuilder.amount()
+    analytics.sendRevenueEvent(new BigDecimal(inAppPurchaseInteractor.convertToFiat((new BigDecimal(
+        transactionBuilder.amount()
+            .toString())).doubleValue(), EVENT_REVENUE_CURRENCY)
+        .blockingGet()
+        .getAmount()).setScale(2, BigDecimal.ROUND_UP)
         .toString());
   }
 }

--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/OnChainBuyPresenter.java
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/OnChainBuyPresenter.java
@@ -18,6 +18,8 @@ import java.math.BigDecimal;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 
+import static com.asfoundation.wallet.analytics.FacebookEventLogger.EVENT_REVENUE_CURRENCY;
+
 /**
  * Created by franciscocalado on 19/07/2018.
  */
@@ -250,7 +252,11 @@ public class OnChainBuyPresenter {
 
   public void sendRevenueEvent() {
     disposables.add(transactionBuilder.subscribe(transactionBuilder -> analytics.sendRevenueEvent(
-        transactionBuilder.amount()
+        new BigDecimal(inAppPurchaseInteractor.convertToFiat((new BigDecimal(
+            transactionBuilder.amount()
+                .toString())).doubleValue(), EVENT_REVENUE_CURRENCY)
+            .blockingGet()
+            .getAmount()).setScale(2, BigDecimal.ROUND_UP)
             .toString())));
   }
 

--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/OnChainBuyPresenter.java
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/OnChainBuyPresenter.java
@@ -251,30 +251,10 @@ public class OnChainBuyPresenter {
   }
 
   public void sendRevenueEvent() {
-    disposables.add(transactionBuilder.subscribe(transactionBuilder -> analytics.sendRevenueEvent(
-        new BigDecimal(inAppPurchaseInteractor.convertToFiat((new BigDecimal(
-            transactionBuilder.amount()
-                .toString())).doubleValue(), EVENT_REVENUE_CURRENCY)
-            .blockingGet()
-            .getAmount()).setScale(2, BigDecimal.ROUND_UP)
-            .toString())));
-  }
-
-  public static class BuyData {
-    private final String uri;
-    private final BigDecimal channelBudget;
-
-    public BuyData(String uri, BigDecimal channelBudget) {
-      this.uri = uri;
-      this.channelBudget = channelBudget;
-    }
-
-    public String getUri() {
-      return uri;
-    }
-
-    public BigDecimal getChannelBudget() {
-      return channelBudget;
-    }
+    disposables.add(transactionBuilder.flatMap(
+        transaction -> inAppPurchaseInteractor.convertToFiat((transaction.amount()).doubleValue(),
+            EVENT_REVENUE_CURRENCY))
+        .doOnSuccess(fiatValue -> analytics.sendRevenueEvent(String.valueOf(fiatValue.getAmount())))
+        .subscribe());
   }
 }


### PR DESCRIPTION
Correction of the conversion from APPC to EUR when sending the Facebook revenue events.