### PR TITLE
[APPC-1067] Gamification info icon now appears when dismissing view

### DIFF
--- a/app/src/main/java/com/asfoundation/wallet/ui/gamification/GamificationView.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/gamification/GamificationView.kt
@@ -4,4 +4,5 @@ interface GamificationView {
   fun closeHowItWorksView()
   fun showHowItWorksView()
   fun showHowItWorksButton()
+  fun onHowItWorksClosed()
 }

--- a/app/src/main/java/com/asfoundation/wallet/ui/gamification/HowItWorksFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/gamification/HowItWorksFragment.kt
@@ -82,6 +82,7 @@ class HowItWorksFragment : DaggerFragment(), HowItWorksView {
   }
 
   override fun onDestroyView() {
+    gamificationView.showHowItWorksButton()
     presenter.stop()
     super.onDestroyView()
   }

--- a/app/src/main/java/com/asfoundation/wallet/ui/gamification/HowItWorksFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/gamification/HowItWorksFragment.kt
@@ -82,7 +82,7 @@ class HowItWorksFragment : DaggerFragment(), HowItWorksView {
   }
 
   override fun onDestroyView() {
-    gamificationView.showHowItWorksButton()
+    gamificationView.onHowItWorksClosed()
     presenter.stop()
     super.onDestroyView()
   }

--- a/app/src/main/java/com/asfoundation/wallet/ui/gamification/RewardsLevelActivity.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/gamification/RewardsLevelActivity.kt
@@ -66,7 +66,6 @@ class RewardsLevelActivity : BaseActivity(), GamificationView {
         supportFragmentManager.beginTransaction().remove(currentFragment).commit()
       }
       supportFragmentManager.popBackStackImmediate()
-      menu.findItem(R.id.action_info).isVisible = true
     }
   }
 

--- a/app/src/main/java/com/asfoundation/wallet/ui/gamification/RewardsLevelActivity.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/gamification/RewardsLevelActivity.kt
@@ -81,7 +81,9 @@ class RewardsLevelActivity : BaseActivity(), GamificationView {
   }
 
   override fun onHowItWorksClosed() {
-    if (gameficationAvailable) menu.findItem(R.id.action_info).isVisible = true
+    if (gameficationAvailable) {
+      menu.findItem(R.id.action_info).isVisible = true
+    }
   }
 
   override fun showHowItWorksButton() {

--- a/app/src/main/java/com/asfoundation/wallet/ui/gamification/RewardsLevelActivity.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/gamification/RewardsLevelActivity.kt
@@ -10,6 +10,7 @@ import com.asfoundation.wallet.ui.BaseActivity
 class RewardsLevelActivity : BaseActivity(), GamificationView {
 
   lateinit var menu: Menu
+  private var gameficationAvailable = false
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
@@ -55,10 +56,11 @@ class RewardsLevelActivity : BaseActivity(), GamificationView {
     return super.onCreateOptionsMenu(menu)
   }
 
+
   override fun closeHowItWorksView() {
     val currentFragment = supportFragmentManager.findFragmentById(R.id.fragment_container)
 
-    if (currentFragment  != null && supportFragmentManager.backStackEntryCount > 0) {
+    if (currentFragment != null && supportFragmentManager.backStackEntryCount > 0) {
       val fragment =
           supportFragmentManager.findFragmentByTag(HowItWorksFragment::class.java.simpleName)
       if (fragment != null && fragment::class.java.name.equals(
@@ -78,7 +80,12 @@ class RewardsLevelActivity : BaseActivity(), GamificationView {
 
   }
 
+  override fun onHowItWorksClosed() {
+    if (gameficationAvailable) menu.findItem(R.id.action_info).isVisible = true
+  }
+
   override fun showHowItWorksButton() {
+    gameficationAvailable = true
     menu.findItem(R.id.action_info).isVisible = true
   }
 }

--- a/app/src/main/java/com/asfoundation/wallet/ui/gamification/RewardsLevelActivity.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/gamification/RewardsLevelActivity.kt
@@ -10,7 +10,7 @@ import com.asfoundation.wallet.ui.BaseActivity
 class RewardsLevelActivity : BaseActivity(), GamificationView {
 
   lateinit var menu: Menu
-  private var gameficationAvailable = false
+  private var gamificationAvailable = false
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
@@ -81,13 +81,13 @@ class RewardsLevelActivity : BaseActivity(), GamificationView {
   }
 
   override fun onHowItWorksClosed() {
-    if (gameficationAvailable) {
+    if (gamificationAvailable) {
       menu.findItem(R.id.action_info).isVisible = true
     }
   }
 
   override fun showHowItWorksButton() {
-    gameficationAvailable = true
+    gamificationAvailable = true
     menu.findItem(R.id.action_info).isVisible = true
   }
 }


### PR DESCRIPTION
**What does this PR do?**

Fixes a bug that would make the info button not appear after dismissing the how it works view by pressing back or outside the view

**Where should the reviewer start?**

MyLevelFragment.kt
RewardsLevelActivity.kt

**How should this be manually tested?**

https://aptoide.atlassian.net/browse/APPC-1067

**What are the relevant tickets?**

https://aptoide.atlassian.net/browse/APPC-1067