### PR TITLE
APPC-1093 Wallet crash when substring "AppCoins Wallet" is not found 

### DIFF
--- a/app/src/main/java/com/asfoundation/wallet/permissions/request/view/PermissionFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/permissions/request/view/PermissionFragment.kt
@@ -87,9 +87,11 @@ class PermissionFragment : DaggerFragment(), PermissionFragmentView {
           val spannedMessage = SpannableString(message)
           val walletAppName = "AppCoins Wallet"
 
-          spannedMessage.setSpan(StyleSpan(BOLD), message.indexOf(walletAppName),
-              message.indexOf(walletAppName) + walletAppName.length,
-              Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
+          if (message.indexOf(walletAppName) > -1) {
+            spannedMessage.setSpan(StyleSpan(BOLD), message.indexOf(walletAppName),
+                message.indexOf(walletAppName) + walletAppName.length,
+                Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
+          }
           spannedMessage.setSpan(StyleSpan(BOLD), message.indexOf(app.appName.toString()),
               message.indexOf(app.appName.toString()) + app.appName.length,
               Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)


### PR DESCRIPTION
**What does this PR do?**
   
This is a quick fix to prevent a wallet to crash when the permissions dialog is shown in a language where the text does not contains the string "AppCoins Wallet"

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] PermissionFragment.kt

**How should this be manually tested?**

  Please use as a test reference the following ticket: [APPC-1075](https://aptoide.atlassian.net/browse/APPC-1075)

Remember to use the device in a non english language

**What are the relevant tickets?**

  Tickets related to this pull-request: [APPC-1093](https://aptoide.atlassian.net/browse/APPC-1093)

**Questions:**

   Does this add new dependencies which need to be added? No

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass