### PR TITLE
[APPC-1095] Fixed reusing the same animation after opening from backg…

### DIFF
--- a/app/src/main/java/com/asfoundation/wallet/ui/onboarding/OnboardingActivity.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/onboarding/OnboardingActivity.kt
@@ -101,6 +101,7 @@ class OnboardingActivity : BaseActivity(), OnboardingView {
   override fun showLoading() {
     onboarding_content.visibility = View.GONE
     wallet_creation_animation.visibility = View.VISIBLE
+    create_wallet_animation.setAnimation(R.raw.create_wallet_loading_animation)
     create_wallet_animation.playAnimation()
   }
 


### PR DESCRIPTION

**What does this PR do?**

   This PR fixes a bug introduced i the last commit that was causing an animation to be displayed twice

**Database changed?**

No

**Where should the reviewer start?**

- [ ] OnboardingActivity.kt

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [APPC-1095](https://aptoide.atlassian.net/browse/APPC-1095)

**What are the relevant tickets?**

  Tickets related to this pull-request: [APPC-1095](https://aptoide.atlassian.net/browse/APPC-1095)




**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass