### PR TITLE
[APPC-1105] Fixed app crashing if wallet isn't loaded

### DIFF
--- a/app/src/main/java/com/asfoundation/wallet/router/ChangeTokenCollectionRouter.java
+++ b/app/src/main/java/com/asfoundation/wallet/router/ChangeTokenCollectionRouter.java
@@ -10,6 +10,9 @@ import static com.asfoundation.wallet.C.Key.WALLET;
 public class ChangeTokenCollectionRouter {
 
   public void open(Context context, Wallet wallet) {
+    if (wallet == null) {
+      return;
+    }
     Intent intent = new Intent(context, TokenChangeCollectionActivity.class);
     intent.putExtra(WALLET, wallet);
     context.startActivity(intent);

--- a/app/src/main/java/com/asfoundation/wallet/router/MyAddressRouter.java
+++ b/app/src/main/java/com/asfoundation/wallet/router/MyAddressRouter.java
@@ -10,6 +10,9 @@ import static com.asfoundation.wallet.C.Key.WALLET;
 public class MyAddressRouter {
 
   public void open(Context context, Wallet wallet) {
+    if (wallet == null) {
+      return;
+    }
     Intent intent = new Intent(context, MyAddressActivity.class);
     intent.putExtra(WALLET, wallet);
     context.startActivity(intent);

--- a/app/src/main/java/com/asfoundation/wallet/router/MyTokensRouter.java
+++ b/app/src/main/java/com/asfoundation/wallet/router/MyTokensRouter.java
@@ -10,6 +10,9 @@ import static com.asfoundation.wallet.C.Key.WALLET;
 public class MyTokensRouter {
 
   public void open(Context context, Wallet wallet) {
+    if (wallet == null) {
+      return;
+    }
     Intent intent = new Intent(context, TokensActivity.class);
     intent.putExtra(WALLET, wallet);
     intent.setFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);


### PR DESCRIPTION
**What does this PR do?**

   This PR prevents the application from crashing if the wallet isn't completely loaded once the user taps on Buttons that passes the wallet address in the Intent

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] ChangeTokenCollectionRouter.java
- [ ] MyAddressRouter.java
- [ ] MyTokensRouter.java

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [APPC-1105](https://aptoide.atlassian.net/browse/APPC-1105)

**What are the relevant tickets?**

  Tickets related to this pull-request: [APPC-1105](https://aptoide.atlassian.net/browse/APPC-1105)