### PR TITLE
[APPC-1077] Changed the way of rounding up the values on all currencies

### DIFF
--- a/app/src/main/java/com/asfoundation/wallet/interact/GetDefaultWalletBalance.java
+++ b/app/src/main/java/com/asfoundation/wallet/interact/GetDefaultWalletBalance.java
@@ -57,13 +57,13 @@ public class GetDefaultWalletBalance implements BalanceService {
 
   private Single<Balance> getTokenBalance(Token token, int scale) {
     return Single.just(new Balance(token.tokenInfo.symbol.toUpperCase(),
-        weiToEth(token.balance).setScale(scale, RoundingMode.HALF_DOWN)
+        weiToEth(token.balance).setScale(scale, RoundingMode.FLOOR)
             .stripTrailingZeros()
             .toPlainString()));
   }
 
   private Single<Balance> getCreditsBalance(BigDecimal value) {
-    return Single.just(new Balance("APPC-C", weiToEth(value).setScale(2, RoundingMode.HALF_DOWN)
+    return Single.just(new Balance("APPC-C", weiToEth(value).setScale(2, RoundingMode.FLOOR)
         .stripTrailingZeros()
         .toPlainString()));
   }
@@ -72,7 +72,7 @@ public class GetDefaultWalletBalance implements BalanceService {
     return walletRepository.balanceInWei(wallet)
         .flatMap(ethBalance -> {
           return Single.just(new Balance(defaultNetwork.symbol,
-              weiToEth(ethBalance).setScale(4, RoundingMode.HALF_DOWN)
+              weiToEth(ethBalance).setScale(4, RoundingMode.FLOOR)
                   .stripTrailingZeros()
                   .toPlainString()));
         })

--- a/app/src/main/java/com/asfoundation/wallet/service/LocalCurrencyConversionService.java
+++ b/app/src/main/java/com/asfoundation/wallet/service/LocalCurrencyConversionService.java
@@ -27,13 +27,13 @@ public class LocalCurrencyConversionService {
   public Observable<FiatValue> getAppcToLocalFiat(String value) {
     return tokenToLocalFiatApi.getValueToLocalFiat(value, "APPC")
         .map(response -> new FiatValue(response.getAppcValue()
-            .setScale(2, RoundingMode.CEILING), response.getCurrency(), response.getSymbol()));
+            .setScale(2, RoundingMode.FLOOR), response.getCurrency(), response.getSymbol()));
   }
 
   public Observable<FiatValue> getEtherToLocalFiat(String value) {
     return tokenToLocalFiatApi.getValueToLocalFiat(value, "ETH")
         .map(response -> new FiatValue(response.getAppcValue()
-            .setScale(2, RoundingMode.CEILING), response.getCurrency(), response.getSymbol()));
+            .setScale(2, RoundingMode.FLOOR), response.getCurrency(), response.getSymbol()));
   }
 
   public Observable<FiatValue> getLocalToAppc(String currency, String value) {


### PR DESCRIPTION
**What does this PR do?**

   All currencies now truncate the value instead of rounding up

**Database changed?**

No

**Where should the reviewer start?**

LocalCurrencyConversionService
GetDefaultWalletBalance

**How should this be manually tested?**

Transfer 0.01 APPC-C to a wallet. It should only display €0.00
Transfer more APPC-C in order to give a total of €0.01 (little above), and check if it shows €0.01 and the value in APPC-C
**What are the relevant tickets?**

https://aptoide.atlassian.net/browse/APPC-1077



**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass