### PR TITLE
[APPC-1113] Added background wallet creation on PoA start

### DIFF
--- a/app/src/main/java/com/asfoundation/wallet/advertise/WalletPoAService.java
+++ b/app/src/main/java/com/asfoundation/wallet/advertise/WalletPoAService.java
@@ -80,6 +80,7 @@ public class WalletPoAService extends Service {
     if (intent != null && intent.hasExtra(PARAM_APP_PACKAGE_NAME)) {
       startNotifications();
       handlePoaStartToSendEvent();
+      handleCreateWallet();
       handlePoaCompletedToSendEvent();
       if (!isBound) {
         // set the chain id received from the application. If not received, it is set as the main
@@ -123,6 +124,10 @@ public class WalletPoAService extends Service {
   @Override public void onRebind(Intent intent) {
     isBound = true;
     super.onRebind(intent);
+  }
+
+  private void handleCreateWallet() {
+    proofOfAttentionService.handleCreateWallet();
   }
 
   private void showGenericErrorNotificationAndStopForeground() {

--- a/app/src/main/java/com/asfoundation/wallet/di/ToolsModule.java
+++ b/app/src/main/java/com/asfoundation/wallet/di/ToolsModule.java
@@ -486,11 +486,13 @@ import static com.asfoundation.wallet.service.AppsApi.API_BASE_URL;
   @Singleton @Provides ProofOfAttentionService provideProofOfAttentionService(
       HashCalculator hashCalculator, ProofWriter proofWriter, TaggedCompositeDisposable disposables,
       @Named("MAX_NUMBER_PROOF_COMPONENTS") int maxNumberProofComponents,
-      CountryCodeProvider countryCodeProvider, AddressService addressService) {
+      CountryCodeProvider countryCodeProvider, AddressService addressService,
+      CreateWalletInteract createWalletInteract,
+      FindDefaultWalletInteract findDefaultWalletInteract) {
     return new ProofOfAttentionService(new MemoryCache<>(BehaviorSubject.create(), new HashMap<>()),
         BuildConfig.APPLICATION_ID, hashCalculator, new CompositeDisposable(), proofWriter,
         Schedulers.computation(), maxNumberProofComponents, new BackEndErrorMapper(), disposables,
-        countryCodeProvider, addressService);
+        countryCodeProvider, addressService, createWalletInteract, findDefaultWalletInteract);
   }
 
   @Provides @Singleton CountryCodeProvider providesCountryCodeProvider(OkHttpClient client,

--- a/app/src/test/java/com/asfoundation/wallet/poa/ProofOfAttentionServiceTest.java
+++ b/app/src/test/java/com/asfoundation/wallet/poa/ProofOfAttentionServiceTest.java
@@ -4,6 +4,7 @@ import com.appcoins.wallet.commons.MemoryCache;
 import com.asf.wallet.BuildConfig;
 import com.asfoundation.wallet.billing.partners.AddressService;
 import com.asfoundation.wallet.entity.Wallet;
+import com.asfoundation.wallet.interact.CreateWalletInteract;
 import com.asfoundation.wallet.interact.FindDefaultWalletInteract;
 import com.asfoundation.wallet.repository.BdsBackEndWriter;
 import com.asfoundation.wallet.repository.WalletNotFoundException;
@@ -35,14 +36,16 @@ import static org.mockito.Mockito.when;
 
 public class ProofOfAttentionServiceTest {
 
-  public static final String SUBMIT_HASH = "hash";
-  public static final String STORE_ADDRESS = "store_address";
-  public static final String OEM_ADDRESS = "oem_address";
+  private static final String SUBMIT_HASH = "hash";
+  private static final String STORE_ADDRESS = "store_address";
+  private static final String OEM_ADDRESS = "oem_address";
 
   @Mock FindDefaultWalletInteract defaultWalletInteract;
   @Mock PoASubmissionService poaSubmissionService;
   @Mock HashCalculator hashCalculator;
   @Mock AddressService addressService;
+  @Mock CreateWalletInteract walletInteract;
+  @Mock FindDefaultWalletInteract findDefaultWalletInteract;
   private int chainId;
   private ProofOfAttentionService proofOfAttentionService;
   private MemoryCache<String, Proof> cache;
@@ -63,7 +66,7 @@ public class ProofOfAttentionServiceTest {
         new ProofOfAttentionService(cache, BuildConfig.APPLICATION_ID, hashCalculator,
             new CompositeDisposable(), proofWriter, testScheduler, maxNumberProofComponents,
             new BackEndErrorMapper(), new TaggedCompositeDisposable(new HashMap<>()),
-            () -> Single.just("PT"), addressService);
+            () -> Single.just("PT"), addressService, walletInteract, findDefaultWalletInteract);
     if (BuildConfig.DEBUG) {
       chainId = 3;
     } else {
@@ -345,7 +348,7 @@ public class ProofOfAttentionServiceTest {
   }
 
   @Test public void wrongNetwork() {
-    int wrongChainId = -1;
+    int wrongChainId;
     wrongChainId = chainId == 3 ? 1 : 3;
     TestObserver<ProofSubmissionFeeData> noFunds =
         proofOfAttentionService.isWalletReady(wrongChainId)


### PR DESCRIPTION
**What does this PR do?**

   This PR adds a feature to create the wallet in background after the PoA starts instead of returning an error

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] WalletPoAService.java
- [ ] ToolsModule.java
- [ ] ProofOfAttentionService.java
- [ ] ProofOfAttentionServiceTest.java

**How should this be manually tested?**

Delete all the data in the wallet. 
Start trivia and check if the PoA doesn't throw a notification saying the wallet isn't configured yet.

  Flow on how to test this or QA Tickets related to this use-case: [APPC-1113](https://aptoide.atlassian.net/browse/APPC-1113)

**What are the relevant tickets?**

  Tickets related to this pull-request: [APPC-1113](https://aptoide.atlassian.net/browse/APPC-1113)

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass