### PR TITLE
Feature/appc 1113 add wallet creation as part of the po a flow

### DIFF
--- a/app/src/main/java/com/asfoundation/wallet/advertise/WalletPoAService.java
+++ b/app/src/main/java/com/asfoundation/wallet/advertise/WalletPoAService.java
@@ -83,15 +83,14 @@ public class WalletPoAService extends Service {
     if (intent != null && intent.hasExtra(PARAM_APP_PACKAGE_NAME)) {
       startNotifications();
       handlePoaStartToSendEvent();
-      handleCreateWallet();
       handlePoaCompletedToSendEvent();
 
       if (!isBound) {
         // set the chain id received from the application. If not received, it is set as the main
         String packageName = intent.getStringExtra(PARAM_APP_PACKAGE_NAME);
 
-        requirementsDisposable = proofOfAttentionService.getWalletCreated()
-            .flatMapSingle(aBoolean -> proofOfAttentionService.isWalletReady(
+        requirementsDisposable = proofOfAttentionService.handleCreateWallet()
+            .flatMap(aBoolean -> proofOfAttentionService.isWalletReady(
                 intent.getIntExtra(PARAM_NETWORK_ID, -1))
                 // network chain id
                 .doOnSuccess(requirementsStatus -> proofOfAttentionService.setChainId(packageName,
@@ -130,10 +129,6 @@ public class WalletPoAService extends Service {
   @Override public void onRebind(Intent intent) {
     isBound = true;
     super.onRebind(intent);
-  }
-
-  private void handleCreateWallet() {
-    proofOfAttentionService.handleCreateWallet();
   }
 
   private void showGenericErrorNotificationAndStopForeground() {

--- a/app/src/main/java/com/asfoundation/wallet/advertise/WalletPoAService.java
+++ b/app/src/main/java/com/asfoundation/wallet/advertise/WalletPoAService.java
@@ -85,11 +85,14 @@ public class WalletPoAService extends Service {
       handlePoaStartToSendEvent();
       handleCreateWallet();
       handlePoaCompletedToSendEvent();
+
       if (!isBound) {
         // set the chain id received from the application. If not received, it is set as the main
         String packageName = intent.getStringExtra(PARAM_APP_PACKAGE_NAME);
-        requirementsDisposable =
-            proofOfAttentionService.isWalletReady(intent.getIntExtra(PARAM_NETWORK_ID, -1))
+
+        requirementsDisposable = proofOfAttentionService.getWalletCreated()
+            .flatMapSingle(aBoolean -> proofOfAttentionService.isWalletReady(
+                intent.getIntExtra(PARAM_NETWORK_ID, -1))
                 // network chain id
                 .doOnSuccess(requirementsStatus -> proofOfAttentionService.setChainId(packageName,
                     intent.getIntExtra(PARAM_NETWORK_ID, -1)))
@@ -98,12 +101,12 @@ public class WalletPoAService extends Service {
                         proofSubmissionFeeData.getGasPrice(), proofSubmissionFeeData.getGasLimit()))
                 .doOnSuccess(
                     requirementsStatus -> processWalletState(requirementsStatus.getStatus(),
-                        intent))
-                .subscribe(requirementsStatus -> {
-                }, throwable -> {
-                  logger.log(throwable);
-                  showGenericErrorNotificationAndStopForeground();
-                });
+                        intent)))
+            .subscribe(requirementsStatus -> {
+            }, throwable -> {
+              logger.log(throwable);
+              showGenericErrorNotificationAndStopForeground();
+            });
       }
       setTimeout(intent.getStringExtra(PARAM_APP_PACKAGE_NAME));
     }


### PR DESCRIPTION
**What does this PR do?**

This PR fixes an edge case where on slower devices the wallet wasn't created before the PoA process started.
With this PR the handshake completes only when the wallet is created

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] WalletPoAService.java
- [ ] ProofOfAttentionService.java 

**How should this be manually tested?**

On Moto G, install the wallet, start trivial drive and check if the wallet returns an error or if the PoA is able to install the wallet in the background.

  Flow on how to test this or QA Tickets related to this use-case: [APPC-1113](https://aptoide.atlassian.net/browse/APPC-1113)

**What are the relevant tickets?**

  Tickets related to this pull-request: [APPC-1113](https://aptoide.atlassian.net/browse/APPC-1113)