### PR TITLE
[APPC-1115] Fixed error mapping on sms and code request services

### DIFF
--- a/app/src/main/java/com/asfoundation/wallet/di/RepositoriesModule.java
+++ b/app/src/main/java/com/asfoundation/wallet/di/RepositoriesModule.java
@@ -139,7 +139,7 @@ import static com.asfoundation.wallet.C.ROPSTEN_NETWORK_NAME;
   }
 
   @Singleton @Provides SmsValidationRepositoryType provideSmsValidationRepository(
-      SmsValidationApi smsValidationApi) {
-    return new SmsValidationRepository(smsValidationApi);
+      SmsValidationApi smsValidationApi, Gson gson) {
+    return new SmsValidationRepository(smsValidationApi, gson);
   }
 }

--- a/app/src/main/java/com/asfoundation/wallet/repository/SmsValidationRepository.kt
+++ b/app/src/main/java/com/asfoundation/wallet/repository/SmsValidationRepository.kt
@@ -39,9 +39,12 @@ class SmsValidationRepository(
   private fun mapError(throwable: Throwable): WalletValidationStatus {
     return when (throwable) {
       is HttpException -> {
-        val walletValidationException = gson.fromJson(throwable.response()
-            .errorBody()!!
-            .charStream(), WalletValidationException::class.java)
+        var walletValidationException = WalletValidationException("")
+        if (throwable.code() == 400) {
+          walletValidationException = gson.fromJson(throwable.response()
+              .errorBody()!!
+              .charStream(), WalletValidationException::class.java)
+        }
         when {
           throwable.code() == 400 && walletValidationException.status == "INVALID_INPUT" -> WalletValidationStatus.INVALID_INPUT
           throwable.code() == 400 && walletValidationException.status == "INVALID_PHONE" -> WalletValidationStatus.INVALID_PHONE

--- a/app/src/main/java/com/asfoundation/wallet/repository/SmsValidationRepository.kt
+++ b/app/src/main/java/com/asfoundation/wallet/repository/SmsValidationRepository.kt
@@ -15,7 +15,7 @@ class SmsValidationRepository(
 
   override fun isValid(walletAddress: String): Single<WalletValidationStatus> {
     return api.isValid(walletAddress)
-        .map(this::mapResponse)
+        .map(this::mapValidationResponse)
         .onErrorReturn(this::mapError)
   }
 
@@ -28,12 +28,16 @@ class SmsValidationRepository(
   override fun validateCode(phoneNumber: String, walletAddress: String,
                             validationCode: String): Single<WalletValidationStatus> {
     return api.validateCode(phoneNumber, walletAddress, validationCode)
-        .map(this::mapResponse)
+        .map(this::mapCodeValidationResponse)
         .onErrorReturn(this::mapError)
   }
 
-  private fun mapResponse(walletStatus: WalletStatus): WalletValidationStatus {
+  private fun mapValidationResponse(walletStatus: WalletStatus): WalletValidationStatus {
     return if (walletStatus.verified) WalletValidationStatus.SUCCESS else WalletValidationStatus.GENERIC_ERROR
+  }
+
+  private fun mapCodeValidationResponse(walletStatus: WalletStatus): WalletValidationStatus {
+    return if (walletStatus.verified) WalletValidationStatus.SUCCESS else WalletValidationStatus.INVALID_INPUT
   }
 
   private fun mapError(throwable: Throwable): WalletValidationStatus {

--- a/app/src/main/java/com/asfoundation/wallet/topup/TopUpFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/topup/TopUpFragment.kt
@@ -44,7 +44,7 @@ class TopUpFragment : DaggerFragment(), TopUpFragmentView {
   private var selectedCurrency = FIAT_CURRENCY
   private var switchingCurrency = false
   private var validBonus = false
-  private lateinit var bonusMessageValue: String
+  private var bonusMessageValue: String = ""
   private var localCurrency = LocalCurrency()
 
   companion object {

--- a/app/src/test/java/com/asfoundation/wallet/repository/SmsValidationRepositoryTest.kt
+++ b/app/src/test/java/com/asfoundation/wallet/repository/SmsValidationRepositoryTest.kt
@@ -4,6 +4,7 @@ import com.asfoundation.wallet.entity.WalletRequestCodeResponse
 import com.asfoundation.wallet.entity.WalletStatus
 import com.asfoundation.wallet.service.SmsValidationApi
 import com.asfoundation.wallet.wallet_validation.WalletValidationStatus
+import com.google.gson.Gson
 import io.reactivex.Single
 import org.junit.Before
 import org.junit.Test
@@ -17,7 +18,8 @@ class SmsValidationRepositoryTest {
 
   @Mock
   lateinit var smsValidationApi: SmsValidationApi
-
+  @Mock
+  lateinit var gson: Gson
   private lateinit var smsValidationRepository: SmsValidationRepository
   private lateinit var walletAddress: String
   private lateinit var phoneNumber: String
@@ -29,7 +31,7 @@ class SmsValidationRepositoryTest {
     phoneNumber = "00351912475564"
     code = "0345671"
 
-    smsValidationRepository = SmsValidationRepository(smsValidationApi)
+    smsValidationRepository = SmsValidationRepository(smsValidationApi, gson)
   }
 
   @Test


### PR DESCRIPTION
**What does this PR do?**

 Previously the user displayed to the user was always “A generic erro has occurred”. This PR changes that and now displays the correct error.

**Where should the reviewer start?**

SmsValidationRepository.kt

**How should this be manually tested?**

Make at least one of the errors appear and see if it’s not a generic string

**What are the relevant tickets?**

 https://aptoide.atlassian.net/browse/APPC-1115


**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass