### PR TITLE
[APPC-1177] SMS validation not working properly when internet connection is lost and regain

### DIFF
--- a/app/src/main/java/com/asfoundation/wallet/wallet_validation/PhoneValidationPresenter.kt
+++ b/app/src/main/java/com/asfoundation/wallet/wallet_validation/PhoneValidationPresenter.kt
@@ -53,16 +53,19 @@ class PhoneValidationPresenter(
       WalletValidationStatus.SUCCESS -> activity?.showCodeValidationView(submitInfo.first,
           submitInfo.second)
       WalletValidationStatus.INVALID_INPUT,
-      WalletValidationStatus.INVALID_PHONE -> handleError(
-          R.string.verification_insert_phone_field_number_error)
-      WalletValidationStatus.DOUBLE_SPENT -> handleError(
-          R.string.verification_insert_phone_field_phone_used_already_error)
-      WalletValidationStatus.GENERIC_ERROR -> handleError(R.string.unknown_error)
+      WalletValidationStatus.INVALID_PHONE -> {
+        showErrorMessage(R.string.verification_insert_phone_field_number_error)
+        view.setButtonState(false)
+      }
+      WalletValidationStatus.DOUBLE_SPENT -> {
+        showErrorMessage(R.string.verification_insert_phone_field_phone_used_already_error)
+        view.setButtonState(false)
+      }
+      WalletValidationStatus.GENERIC_ERROR -> showErrorMessage(R.string.unknown_error)
     }
   }
 
-  private fun handleError(errorMessage: Int) {
-    view.setButtonState(false)
+  private fun showErrorMessage(errorMessage: Int) {
     view.setError(errorMessage)
   }
 


### PR DESCRIPTION
**What does this PR do?**

   This PR fixes a scenario where if the internet is turned off in the phone validation screen before submitting the phone number the submit button would be disabled until the user changed any digit

**Database changed?**

  No

**Where should the reviewer start?**

- [ ] PhoneValidationPresenter.kt

**How should this be manually tested?**

Send all proofs of the PoA → Go to the first SMS verification screen → Disconnect from internet → Type a number → Press “Submit” → Connect to the internet

  Flow on how to test this or QA Tickets related to this use-case: [APPC-1177](https://aptoide.atlassian.net/browse/APPC-1177)

**What are the relevant tickets?**

  Tickets related to this pull-request: [APPC-1177](https://aptoide.atlassian.net/browse/APPC-1177)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new libs, new keys, etc.)




**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass