### PR TITLE
[bugfix/APPC-1156] - PoA notification UX fix

### DIFF
--- a/app/src/main/java/com/asfoundation/wallet/advertise/WalletPoAService.java
+++ b/app/src/main/java/com/asfoundation/wallet/advertise/WalletPoAService.java
@@ -268,7 +268,7 @@ public class WalletPoAService extends Service {
                 .build());
         break;
       case PHONE_NOT_VERIFIED:
-        stopForeground(false);
+        stopForeground(true);
         notificationManager.cancel(SERVICE_ID);
         notificationManager.notify(VERIFICATION_SERVICE_ID,
             createVerificationNotification().build());

--- a/app/src/main/java/com/asfoundation/wallet/advertise/WalletPoAService.java
+++ b/app/src/main/java/com/asfoundation/wallet/advertise/WalletPoAService.java
@@ -268,6 +268,8 @@ public class WalletPoAService extends Service {
                 .build());
         break;
       case PHONE_NOT_VERIFIED:
+        stopForeground(false);
+        notificationManager.cancel(SERVICE_ID);
         notificationManager.notify(VERIFICATION_SERVICE_ID,
             createVerificationNotification().build());
         break;
@@ -317,6 +319,8 @@ public class WalletPoAService extends Service {
     return builder.setContentTitle(getString(R.string.app_name))
         .setSmallIcon(R.drawable.ic_launcher_foreground)
         .setPriority(NotificationCompat.PRIORITY_MAX)
+        .setAutoCancel(true)
+        .setOngoing(false)
         .setContentText(getString(notificationText));
   }
 
@@ -345,8 +349,8 @@ public class WalletPoAService extends Service {
     return builder.setContentTitle(
         getString(R.string.verification_notification_verification_needed_title))
         .setContentIntent(pendingIntent)
-        .setAutoCancel(false)
-        .setOngoing(true)
+        .setAutoCancel(true)
+        .setOngoing(false)
         .setSmallIcon(R.drawable.ic_launcher_foreground)
         .setPriority(NotificationCompat.PRIORITY_MAX)
         .setContentText(getString(R.string.verification_notification_verification_needed_body));


### PR DESCRIPTION
**What does this PR do?**

   1- Closes the blockchain submission notification when the verification notification is shown;
   2- Change the reward received and the verification notifications to be both dismissible on swipe and on click.

**Database changed?**

   No

**Where should the reviewer start?**

- WalletPoAService.java

**How should this be manually tested?**
  
  Normal PoA flow, with wallet verification.

  Flow on how to test this or QA Tickets related to this use-case: [APPC-1156](https://aptoide.atlassian.net/browse/APPC-1156)

**What are the relevant tickets?**

  Tickets related to this pull-request: [APPC-1156](https://aptoide.atlassian.net/browse/APPC-1156)

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass