### PR TITLE
[APPC-1190] Added two buttons to validation notification

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,6 +18,12 @@
       android:testOnly="false"
       android:theme="@style/AppTheme.NoActionBar"
       tools:replace="android:name, android:theme, android:allowBackup">
+    <receiver
+        android:name="com.asfoundation.wallet.wallet_validation.WalletValidationBroadcastReceiver"
+        android:enabled="true"
+        android:exported="false">
+    </receiver>
+
     <meta-data
         android:name="com.facebook.sdk.ApplicationId"
         android:value="@string/facebook_app_id"/>
@@ -31,33 +37,27 @@
         <category android:name="android.intent.category.LAUNCHER"/>
       </intent-filter>
     </activity>
-
     <activity
         android:name="com.asfoundation.wallet.ui.WalletsActivity"
         android:label="@string/title_account_list"/>
-
     <activity
         android:name="com.asfoundation.wallet.ui.onboarding.OnboardingActivity"
         android:label=""
         android:screenOrientation="portrait"/>
-
     <activity
         android:name="com.asfoundation.wallet.ui.ImportWalletActivity"
         android:label="@string/title_import"
         android:windowSoftInputMode="stateAlwaysVisible|adjustResize"/>
-
     <activity
         android:name="com.asfoundation.wallet.ui.TransactionsActivity"
         android:label="@string/app_name"
         android:theme="@style/MaterialAppTheme"/>
-
     <activity
         android:name="com.asfoundation.wallet.ui.SettingsActivity"
         android:label="@string/title_activity_settings"/>
     <activity
         android:name="com.asfoundation.wallet.ui.balance.TransactionDetailActivity"
         android:label=""/>
-
     <activity
         android:name="com.asfoundation.wallet.ui.MyAddressActivity"
         android:label="@string/title_my_address"/>
@@ -66,35 +66,31 @@
         android:label="@string/balance_title"/>
     <activity
         android:name="com.asfoundation.wallet.ui.balance.TokenDetailsActivity"
-        android:theme="@style/AppTheme.Transparent"
-        android:label="@string/balance_title"/>
-
+        android:label="@string/balance_title"
+        android:theme="@style/AppTheme.Transparent"/>
     <activity
         android:name="com.asfoundation.wallet.ui.SendActivity"
         android:label="@string/title_activity_send"/>
-
     <activity
         android:name="com.asfoundation.wallet.ui.ConfirmationActivity"
         android:label="@string/title_activity_confirmation"/>
-
     <activity
         android:name="com.asfoundation.wallet.ui.barcode.BarcodeCaptureActivity"
         android:label="@string/title_activity_barcode"/>
-
     <activity
         android:name="com.asfoundation.wallet.ui.GasSettingsActivity"
         android:label="@string/title_send_settings"/>
-
     <activity
         android:name="com.asfoundation.wallet.ui.Erc681Receiver"
         android:theme="@style/Theme.AppCompat.Transparent.NoDisplay">
       <intent-filter>
         <action android:name="android.intent.action.VIEW"/>
+
         <category android:name="android.intent.category.DEFAULT"/>
+
         <data android:scheme="ethereum"/>
       </intent-filter>
     </activity>
-
     <activity
         android:name="com.asfoundation.wallet.ui.OneStepPaymentReceiver"
         android:theme="@style/Theme.AppCompat.Transparent.NoDisplay">
@@ -110,31 +106,28 @@
         <data android:pathPrefix="/transaction"/>
       </intent-filter>
     </activity>
-
     <activity
         android:name="com.asfoundation.wallet.ui.iab.WebViewActivity"
         android:theme="@style/Theme.AppCompat.Transparent"/>
-
     <activity
         android:name="com.asfoundation.wallet.permissions.request.view.PermissionsActivity"
         android:theme="@style/Theme.AppCompat.Transparent.NoFloating">
       <intent-filter>
         <action android:name="android.intent.action.VIEW"/>
+
         <category android:name="android.intent.category.DEFAULT"/>
+
         <data
             android:host="wallet"
             android:path="/permissions/1"
             android:scheme="appcoins"/>
       </intent-filter>
     </activity>
-
     <activity android:name="com.asfoundation.wallet.permissions.manage.view.ManagePermissionsActivity"/>
-
     <activity
         android:name="com.asfoundation.wallet.ui.iab.IabActivity"
         android:launchMode="singleInstance"
-        android:theme="@style/Theme.AppCompat.Transparent.FitAppWindow"
-        >
+        android:theme="@style/Theme.AppCompat.Transparent.FitAppWindow">
       <intent-filter>
         <action android:name="android.intent.action.VIEW"/>
 
@@ -151,21 +144,17 @@
             android:scheme="billing"/>
       </intent-filter>
     </activity>
-
     <activity
         android:name="com.asfoundation.wallet.ui.airdrop.AirdropActivity"
         android:label="@string/title_airdrop"
         android:screenOrientation="portrait"/>
-
     <activity
         android:name="com.asfoundation.wallet.ui.gamification.RewardsLevelActivity"
         android:label="@string/gamification_level_title"
         android:screenOrientation="portrait"/>
-
     <activity
         android:name="com.asfoundation.wallet.ui.transact.TransferActivity"
         android:label="@string/title_activity_send"/>
-
     <activity
         android:name="com.asfoundation.wallet.topup.TopUpActivity"
         android:label="@string/topup_title">
@@ -180,12 +169,10 @@
             android:scheme="billing"/>
       </intent-filter>
     </activity>
-
     <activity
         android:name="com.asfoundation.wallet.wallet_validation.WalletValidationActivity"
         android:launchMode="singleInstance"
-        android:theme="@style/Theme.AppCompat.Transparent.FitAppWindow"
-        />
+        android:theme="@style/Theme.AppCompat.Transparent.FitAppWindow"/>
 
     <meta-data
         android:name="io.fabric.ApiKey"
@@ -199,7 +186,6 @@
         <action android:name="com.asf.appcoins.service.ACTION_BIND"/>
       </intent-filter>
     </service>
-
     <service
         android:name="com.asfoundation.wallet.advertise.AdvertisingService"
         android:enabled="true"
@@ -217,6 +203,6 @@
         <action android:name="com.asf.appcoins.service.ACTION_START_HANDSHAKE"/>
       </intent-filter>
     </receiver>
-
   </application>
+
 </manifest>

--- a/app/src/main/java/com/asfoundation/wallet/advertise/WalletPoAService.java
+++ b/app/src/main/java/com/asfoundation/wallet/advertise/WalletPoAService.java
@@ -23,7 +23,7 @@ import com.asfoundation.wallet.poa.ProofStatus;
 import com.asfoundation.wallet.poa.ProofSubmissionFeeData;
 import com.asfoundation.wallet.repository.WrongNetworkException;
 import com.asfoundation.wallet.ui.TransactionsActivity;
-import com.asfoundation.wallet.wallet_validation.WalletValidationActivity;
+import com.asfoundation.wallet.wallet_validation.WalletValidationBroadcastReceiver;
 import dagger.android.AndroidInjection;
 import io.reactivex.Observable;
 import io.reactivex.disposables.Disposable;
@@ -41,6 +41,9 @@ import static com.asfoundation.wallet.advertise.ServiceConnector.PARAM_APP_PACKA
 import static com.asfoundation.wallet.advertise.ServiceConnector.PARAM_APP_SERVICE_NAME;
 import static com.asfoundation.wallet.advertise.ServiceConnector.PARAM_NETWORK_ID;
 import static com.asfoundation.wallet.advertise.ServiceConnector.PARAM_WALLET_PACKAGE_NAME;
+import static com.asfoundation.wallet.wallet_validation.WalletValidationBroadcastReceiver.ACTION_DISMISS;
+import static com.asfoundation.wallet.wallet_validation.WalletValidationBroadcastReceiver.ACTION_KEY;
+import static com.asfoundation.wallet.wallet_validation.WalletValidationBroadcastReceiver.ACTION_START_VALIDATION;
 
 /**
  * Created by Joao Raimundo on 29/03/2018.
@@ -342,15 +345,23 @@ public class WalletPoAService extends Service {
       builder.setVibrate(new long[0]);
     }
 
-    Intent intent = WalletValidationActivity.newIntent(this);
-    intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-    PendingIntent pendingIntent = PendingIntent.getActivity(this, 0, intent, 0);
+    Intent okIntent = WalletValidationBroadcastReceiver.newIntent(this);
+    okIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+    okIntent.putExtra(ACTION_KEY, ACTION_START_VALIDATION);
+    PendingIntent okPendingIntent = PendingIntent.getBroadcast(this, 0, okIntent, 0);
+
+    Intent dismissIntent = WalletValidationBroadcastReceiver.newIntent(this);
+    dismissIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+    dismissIntent.putExtra(ACTION_KEY, ACTION_DISMISS);
+    PendingIntent dismissPendingIntent = PendingIntent.getBroadcast(this, 1, dismissIntent, 0);
 
     return builder.setContentTitle(
         getString(R.string.verification_notification_verification_needed_title))
-        .setContentIntent(pendingIntent)
+        .setContentIntent(okPendingIntent)
         .setAutoCancel(true)
-        .setOngoing(false)
+        .setOngoing(true)
+        .addAction(0, getString(R.string.ok), okPendingIntent)
+        .addAction(0, getString(R.string.dismiss_button), dismissPendingIntent)
         .setSmallIcon(R.drawable.ic_launcher_foreground)
         .setPriority(NotificationCompat.PRIORITY_MAX)
         .setContentText(getString(R.string.verification_notification_verification_needed_body));

--- a/app/src/main/java/com/asfoundation/wallet/wallet_validation/WalletValidationBroadcastReceiver.kt
+++ b/app/src/main/java/com/asfoundation/wallet/wallet_validation/WalletValidationBroadcastReceiver.kt
@@ -26,8 +26,8 @@ class WalletValidationBroadcastReceiver : BroadcastReceiver() {
     notificationManager =
         context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
 
-
     notificationManager.cancel(VERIFICATION_SERVICE_ID)
+    context.sendBroadcast(Intent(Intent.ACTION_CLOSE_SYSTEM_DIALOGS))
 
     when (intent.getStringExtra(ACTION_KEY)) {
       ACTION_START_VALIDATION -> {

--- a/app/src/main/java/com/asfoundation/wallet/wallet_validation/WalletValidationBroadcastReceiver.kt
+++ b/app/src/main/java/com/asfoundation/wallet/wallet_validation/WalletValidationBroadcastReceiver.kt
@@ -1,0 +1,41 @@
+package com.asfoundation.wallet.wallet_validation
+
+import android.app.NotificationManager
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import com.asfoundation.wallet.advertise.WalletPoAService.VERIFICATION_SERVICE_ID
+
+class WalletValidationBroadcastReceiver : BroadcastReceiver() {
+
+  private lateinit var notificationManager: NotificationManager
+
+  companion object {
+
+    const val ACTION_KEY = "ACTION_KEY"
+    const val ACTION_START_VALIDATION = "ACTION_START_VALIDATION"
+    const val ACTION_DISMISS = "ACTION_DISMISS"
+
+    @JvmStatic
+    fun newIntent(context: Context): Intent {
+      return Intent(context, WalletValidationBroadcastReceiver::class.java)
+    }
+  }
+
+  override fun onReceive(context: Context, intent: Intent) {
+    notificationManager =
+        context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+
+
+    notificationManager.cancel(VERIFICATION_SERVICE_ID)
+
+    when (intent.getStringExtra(ACTION_KEY)) {
+      ACTION_START_VALIDATION -> {
+        val validationIntent = WalletValidationActivity.newIntent(context)
+        validationIntent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
+        context.startActivity(validationIntent)
+      }
+      ACTION_DISMISS -> return
+    }
+  }
+}


### PR DESCRIPTION
**What does this PR do?**

  This PR changes the existing verification notification to support validation and dismiss actions using two buttons in the notification itself.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] WalletPoAService.java
- [ ] WalletValidationBroadcastReceiver.kt

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [APPC-1190](https://aptoide.atlassian.net/browse/APPC-1190)

**What are the relevant tickets?**

  Tickets related to this pull-request: [APPC-1190](https://aptoide.atlassian.net/browse/APPC-1190)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new libs, new keys, etc.)




**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass