### PR TITLE
[APPC-1189] Click on url without browser

### DIFF
--- a/app/src/main/java/com/asfoundation/wallet/router/ExternalBrowserRouter.java
+++ b/app/src/main/java/com/asfoundation/wallet/router/ExternalBrowserRouter.java
@@ -1,13 +1,22 @@
 package com.asfoundation.wallet.router;
 
+import android.content.ActivityNotFoundException;
 import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
+import android.widget.Toast;
+import com.asf.wallet.R;
 
 public class ExternalBrowserRouter {
 
   public void open(Context context, Uri uri) {
-    Intent launchBrowser = new Intent(Intent.ACTION_VIEW, uri);
-    context.startActivity(launchBrowser);
+    try {
+      Intent launchBrowser = new Intent(Intent.ACTION_VIEW, uri);
+      context.startActivity(launchBrowser);
+    } catch (ActivityNotFoundException exception) {
+      exception.printStackTrace();
+      Toast.makeText(context, R.string.unknown_error, Toast.LENGTH_SHORT)
+          .show();
+    }
   }
 }

--- a/app/src/main/java/com/asfoundation/wallet/ui/SettingsFragment.java
+++ b/app/src/main/java/com/asfoundation/wallet/ui/SettingsFragment.java
@@ -1,6 +1,7 @@
 package com.asfoundation.wallet.ui;
 
 import android.app.AlertDialog;
+import android.content.ActivityNotFoundException;
 import android.content.Intent;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
@@ -16,6 +17,7 @@ import com.asf.wallet.R;
 import com.asfoundation.wallet.interact.FindDefaultWalletInteract;
 import com.asfoundation.wallet.permissions.manage.view.ManagePermissionsActivity;
 import com.asfoundation.wallet.router.ManageWalletsRouter;
+import com.google.android.material.snackbar.Snackbar;
 import dagger.android.AndroidInjection;
 import javax.inject.Inject;
 
@@ -35,8 +37,9 @@ public class SettingsFragment extends PreferenceFragment {
     final Preference redeem = findPreference("pref_redeem");
     redeem.setOnPreferenceClickListener(preference -> {
       findDefaultWalletInteract.find()
-          .subscribe(wallet -> startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(
-              BuildConfig.MY_APPCOINS_BASE_HOST + "redeem?wallet_address=" + wallet.address))));
+          .subscribe(wallet -> startBrowserActivity(Uri.parse(
+              BuildConfig.MY_APPCOINS_BASE_HOST + "redeem?wallet_address=" + wallet.address),
+              false));
       return false;
     });
     final Preference wallets = findPreference("pref_wallet");
@@ -69,22 +72,17 @@ public class SettingsFragment extends PreferenceFragment {
         // get the Twitter app if possible
         getActivity().getPackageManager()
             .getPackageInfo("com.twitter.android", 0);
-        intent =
-            new Intent(Intent.ACTION_VIEW, Uri.parse("twitter://user?user_id=915531221551255552"));
-        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+        startBrowserActivity(Uri.parse("twitter://user?user_id=915531221551255552"), true);
       } catch (Exception e) {
         // no Twitter app, revert to browser
-        intent = new Intent(Intent.ACTION_VIEW, Uri.parse("https://twitter.com/AppCoinsProject"));
+        startBrowserActivity(Uri.parse("https://twitter.com/AppCoinsProject"), false);
       }
-      startActivity(intent);
       return false;
     });
 
     final Preference facebook = findPreference("pref_facebook");
     facebook.setOnPreferenceClickListener(preference -> {
-      Intent intent =
-          new Intent(Intent.ACTION_VIEW, Uri.parse("https://www.facebook.com/AppCoinsOfficial"));
-      startActivity(intent);
+      startBrowserActivity(Uri.parse("https://www.facebook.com/AppCoinsOfficial"), false);
       return false;
     });
 
@@ -112,6 +110,38 @@ public class SettingsFragment extends PreferenceFragment {
           .show();
       return true;
     });
+
+    final Preference sourceCode = findPreference("pref_source_code");
+    sourceCode.setOnPreferenceClickListener(preference -> {
+      startBrowserActivity(Uri.parse("https://github.com/Aptoide/appcoins-wallet-android"), false);
+      return false;
+    });
+
+    final Preference bugReport = findPreference("pref_report_bug");
+    bugReport.setOnPreferenceClickListener(preference -> {
+      startBrowserActivity(
+          Uri.parse("https://github.com/Aptoide/appcoins-wallet-android/issues/new"), false);
+      return false;
+    });
+
+    final Preference telegram = findPreference("pref_telegram");
+    telegram.setOnPreferenceClickListener(preference -> {
+      startBrowserActivity(Uri.parse("https://t.me/appcoinsofficial"), false);
+      return false;
+    });
+
+    final Preference privacyPolicy = findPreference("pref_privacy_policy");
+    privacyPolicy.setOnPreferenceClickListener(preference -> {
+      startBrowserActivity(Uri.parse("https://catappult.io/appcoins-wallet/privacy-policy"), false);
+      return false;
+    });
+
+    final Preference termsCondition = findPreference("pref_terms_condition");
+    termsCondition.setOnPreferenceClickListener(preference -> {
+      startBrowserActivity(Uri.parse("https://catappult.io/appcoins-wallet/terms-conditions"),
+          false);
+      return false;
+    });
   }
 
   private boolean openPermissionScreen() {
@@ -129,6 +159,22 @@ public class SettingsFragment extends PreferenceFragment {
       e.printStackTrace();
     }
     return version;
+  }
+
+  private void startBrowserActivity(Uri uri, boolean newTaskFlag) {
+    try {
+      Intent intent = new Intent(Intent.ACTION_VIEW, uri);
+      if (newTaskFlag) {
+        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+      }
+      startActivity(intent);
+    } catch (ActivityNotFoundException exception) {
+      exception.printStackTrace();
+      if (getView() != null) {
+        Snackbar.make(getView(), R.string.unknown_error, Snackbar.LENGTH_SHORT)
+            .show();
+      }
+    }
   }
 }
 

--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/AdyenAuthorizationFragment.java
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/AdyenAuthorizationFragment.java
@@ -145,6 +145,11 @@ public class AdyenAuthorizationFragment extends DaggerFragment implements AdyenA
         getAmount().toString(), getCurrency(), getPaymentType(), analytics, Schedulers.io());
   }
 
+  @Override public View onCreateView(LayoutInflater inflater, ViewGroup container,
+      Bundle savedInstanceState) {
+    return inflater.inflate(R.layout.dialog_credit_card_authorization, container, false);
+  }
+
   @Override public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
     super.onViewCreated(view, savedInstanceState);
 
@@ -215,11 +220,6 @@ public class AdyenAuthorizationFragment extends DaggerFragment implements AdyenA
     presenter.present(savedInstanceState);
   }
 
-  @Override public View onCreateView(LayoutInflater inflater, ViewGroup container,
-      Bundle savedInstanceState) {
-    return inflater.inflate(R.layout.dialog_credit_card_authorization, container, false);
-  }
-
   @Override public void onSaveInstanceState(@NonNull Bundle outState) {
     super.onSaveInstanceState(outState);
 
@@ -246,6 +246,10 @@ public class AdyenAuthorizationFragment extends DaggerFragment implements AdyenA
     changeCardButton = null;
     creditCardInformationsLayout = null;
     walletInformationsFooter = null;
+    lottieTransactionComplete.removeAllAnimatorListeners();
+    lottieTransactionComplete.removeAllUpdateListeners();
+    lottieTransactionComplete.removeAllLottieOnCompositionLoadedListener();
+    lottieTransactionComplete = null;
     transactionCompletedLayout = null;
     mainView = null;
     errorView = null;
@@ -314,6 +318,12 @@ public class AdyenAuthorizationFragment extends DaggerFragment implements AdyenA
         .map(__ -> paymentMethod);
   }
 
+  @Override public void showNetworkError() {
+    mainView.setVisibility(View.GONE);
+    errorView.setVisibility(View.VISIBLE);
+    errorMessage.setText(R.string.notification_no_network_poa);
+  }
+
   @Override public Observable<Object> cancelEvent() {
     return RxView.clicks(cancelButton)
         .mergeWith(backButton);
@@ -379,12 +389,6 @@ public class AdyenAuthorizationFragment extends DaggerFragment implements AdyenA
     walletInformationsFooter.setVisibility(View.GONE);
     transactionCompletedLayout.setVisibility(View.VISIBLE);
     errorView.setVisibility(View.GONE);
-  }
-
-  @Override public void showNetworkError() {
-    mainView.setVisibility(View.GONE);
-    errorView.setVisibility(View.VISIBLE);
-    errorMessage.setText(R.string.notification_no_network_poa);
   }
 
   @Override public void showPaymentRefusedError(AdyenAuthorization adyenAuthorization) {

--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/OnChainBuyFragment.java
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/OnChainBuyFragment.java
@@ -6,8 +6,6 @@ import android.content.pm.PackageManager;
 import android.graphics.Typeface;
 import android.graphics.drawable.Drawable;
 import android.os.Bundle;
-import androidx.annotation.Nullable;
-import androidx.annotation.StringRes;
 import android.text.Spannable;
 import android.text.SpannableString;
 import android.text.Spanned;
@@ -21,6 +19,8 @@ import android.widget.Button;
 import android.widget.ImageView;
 import android.widget.ProgressBar;
 import android.widget.TextView;
+import androidx.annotation.Nullable;
+import androidx.annotation.StringRes;
 import com.airbnb.lottie.FontAssetDelegate;
 import com.airbnb.lottie.LottieAnimationView;
 import com.airbnb.lottie.TextDelegate;
@@ -56,6 +56,7 @@ public class OnChainBuyFragment extends DaggerFragment implements OnChainBuyView
   private static final String TRANSACTION_BUILDER_KEY = "transaction_builder";
   private static final String BONUS_KEY = "bonus";
   @Inject InAppPurchaseInteractor inAppPurchaseInteractor;
+  @Inject BillingAnalytics analytics;
   private PublishRelay<String> buyButtonClick;
   private Button buyButton;
   private Button cancelButton;
@@ -81,7 +82,6 @@ public class OnChainBuyFragment extends DaggerFragment implements OnChainBuyView
   private Bundle extras;
   private String data;
   private boolean isBds;
-  @Inject BillingAnalytics analytics;
   private TransactionBuilder transaction;
   private LottieAnimationView lottieTransactionComplete;
 
@@ -180,6 +180,10 @@ public class OnChainBuyFragment extends DaggerFragment implements OnChainBuyView
 
   @Override public void onDestroyView() {
     presenter.stop();
+    lottieTransactionComplete.removeAllAnimatorListeners();
+    lottieTransactionComplete.removeAllUpdateListeners();
+    lottieTransactionComplete.removeAllLottieOnCompositionLoadedListener();
+    lottieTransactionComplete = null;
     super.onDestroyView();
   }
 
@@ -301,16 +305,16 @@ public class OnChainBuyFragment extends DaggerFragment implements OnChainBuyView
     walletAddressTextView.setText(wallet);
   }
 
+  @Override public long getAnimationDuration() {
+    return lottieTransactionComplete.getDuration();
+  }
+
   @Override public void onAttach(Context context) {
     super.onAttach(context);
     if (!(context instanceof IabView)) {
       throw new IllegalStateException("Regular buy fragment must be attached to IAB activity");
     }
     iabView = ((IabView) context);
-  }
-
-  @Override public long getAnimationDuration() {
-    return lottieTransactionComplete.getDuration();
   }
 
   private void showLoading(@StringRes int message) {

--- a/app/src/main/res/layout/dialog_buy_app_info_header.xml
+++ b/app/src/main/res/layout/dialog_buy_app_info_header.xml
@@ -5,16 +5,16 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
-    android:layout_marginEnd="15dp"
     android:layout_marginStart="15dp"
     android:layout_marginTop="14dp"
+    android:layout_marginEnd="15dp"
     tools:showIn="@layout/fragment_express_checkout_buy"
     >
   <ImageView
       android:id="@+id/app_icon"
       android:layout_width="42dp"
       android:layout_height="42dp"
-      android:src="@drawable/ic_appc"
+      tools:src="@drawable/ic_appc"
       />
   <TextView
       android:id="@+id/app_name"

--- a/app/src/main/res/layout/dialog_buy_app_info_header.xml
+++ b/app/src/main/res/layout/dialog_buy_app_info_header.xml
@@ -14,7 +14,7 @@
       android:id="@+id/app_icon"
       android:layout_width="42dp"
       android:layout_height="42dp"
-      tools:src="@drawable/ic_appc"
+      android:src="@drawable/ic_appc"
       />
   <TextView
       android:id="@+id/app_name"

--- a/app/src/main/res/layout/fragment_express_checkout_buy.xml
+++ b/app/src/main/res/layout/fragment_express_checkout_buy.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/dialog_buy_app"
     android:layout_width="@dimen/payment_methods_width"
     android:layout_height="wrap_content"
+    android:layout_gravity="center"
     android:animateLayoutChanges="true"
     android:background="@drawable/background_card"
+    android:orientation="vertical"
     app:layout_constraintBottom_toBottomOf="parent"
     app:layout_constraintEnd_toEndOf="parent"
     app:layout_constraintStart_toStartOf="parent"
     app:layout_constraintTop_toTopOf="parent"
-    android:orientation="vertical"
-    android:layout_gravity="center"
     >
   <LinearLayout
       android:id="@+id/info_dialog"
@@ -34,9 +34,9 @@
       <RelativeLayout
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
-          android:layout_marginEnd="16dp"
           android:layout_marginStart="23dp"
           android:layout_marginTop="23dp"
+          android:layout_marginEnd="16dp"
           >
         <TextView
             android:id="@+id/sku_description"
@@ -68,8 +68,8 @@
             android:layout_width="match_parent"
             android:layout_height="5dp"
             android:layout_below="@id/sku_description"
-            android:layout_marginBottom="13dp"
             android:layout_marginTop="15dp"
+            android:layout_marginBottom="13dp"
             android:background="@drawable/dashed_line"
             android:layerType="software"
             />
@@ -80,18 +80,18 @@
             android:layout_below="@id/line_separator"
             android:ellipsize="end"
             android:maxLines="1"
-            android:text="Total Price"
             android:textColor="@color/black"
             android:textSize="11sp"
             android:textStyle="bold"
+            tools:text="Total Price"
             />
 
         <TextView
             android:id="@+id/total_price"
             android:layout_width="170dp"
             android:layout_height="wrap_content"
-            android:layout_alignParentEnd="true"
             android:layout_below="@id/line_separator"
+            android:layout_alignParentEnd="true"
             android:ellipsize="end"
             android:maxLines="1"
             android:textAlignment="textEnd"
@@ -114,9 +114,9 @@
           android:id="@+id/logo_wallet"
           android:layout_width="76dp"
           android:layout_height="16dp"
-          android:layout_marginBottom="10dp"
           android:layout_marginStart="16dp"
           android:layout_marginTop="7dp"
+          android:layout_marginBottom="10dp"
           android:src="@drawable/logo_appc_wallet"
           />
 
@@ -125,8 +125,8 @@
           android:layout_width="match_parent"
           android:layout_height="24dp"
           android:layout_marginStart="16dp"
-          android:layout_marginEnd="16dp"
           android:layout_marginTop="4dp"
+          android:layout_marginEnd="16dp"
           android:layout_toEndOf="@id/logo_wallet"
           android:ellipsize="end"
           android:gravity="center_vertical"
@@ -140,8 +140,8 @@
   </LinearLayout>
 
   <include
-      layout="@layout/fragment_iab_error"
       android:id="@+id/error_message"
+      layout="@layout/fragment_iab_error"
       />
 
   <ProgressBar
@@ -187,8 +187,8 @@
         android:layout_width="80dp"
         android:layout_height="80dp"
         android:layout_gravity="center"
-        android:layout_marginBottom="38dp"
         android:layout_marginTop="44dp"
+        android:layout_marginBottom="38dp"
         android:indeterminateDrawable="@drawable/gradient_progress"
         />
   </LinearLayout>

--- a/app/src/main/res/layout/fragment_iab_transaction_completed.xml
+++ b/app/src/main/res/layout/fragment_iab_transaction_completed.xml
@@ -31,6 +31,7 @@
       app:layout_constraintStart_toStartOf="parent"
       app:layout_constraintTop_toBottomOf="@id/transaction_success_text"
       app:lottie_autoPlay="true"
+      app:lottie_enableMergePathsForKitKatAndAbove="true"
       app:lottie_loop="false"
       app:lottie_rawRes="@raw/transaction_complete_bonus_animation"
       />

--- a/app/src/main/res/xml/fragment_settings.xml
+++ b/app/src/main/res/xml/fragment_settings.xml
@@ -27,18 +27,14 @@
 
     <Preference
         android:icon="@mipmap/settings_open_source"
+        android:key="pref_source_code"
         android:title="@string/title_source_code">
-      <intent
-          android:action="android.intent.action.VIEW"
-          android:data="https://github.com/Aptoide/appcoins-wallet-android"/>
     </Preference>
 
     <Preference
         android:icon="@mipmap/settings_bug"
+        android:key="pref_report_bug"
         android:title="@string/title_report_bug">
-      <intent
-          android:action="android.intent.action.VIEW"
-          android:data="https://github.com/Aptoide/appcoins-wallet-android/issues/new"/>
     </Preference>
 
   </PreferenceCategory>
@@ -68,10 +64,8 @@
 
     <Preference
         android:icon="@mipmap/settings_telegram"
+        android:key="pref_telegram"
         android:title="@string/telegram">
-      <intent
-          android:action="android.intent.action.VIEW"
-          android:data="https://t.me/appcoinsofficial"/>
     </Preference>
 
     <Preference
@@ -94,18 +88,14 @@
 
     <Preference
         android:icon="@mipmap/settings_privacy_policy"
+        android:key="pref_privacy_policy"
         android:title="@string/title_privacy_policy">
-      <intent
-          android:action="android.intent.action.VIEW"
-          android:data="https://catappult.io/appcoins-wallet/privacy-policy"/>
     </Preference>
 
     <Preference
         android:icon="@mipmap/settings_terms"
+        android:key="pref_terms_condition"
         android:title="@string/title_terms">
-      <intent
-          android:action="android.intent.action.VIEW"
-          android:data="https://catappult.io/appcoins-wallet/terms-conditions"/>
     </Preference>
 
 


### PR DESCRIPTION
**What does this PR do?**

   This PR fixes 2 bugs. When the user clicks on an url that would open a browser, the app would crash if the user didn’t have any browser
  The other fix is related to changes that were done to fix a crash that would happen if you would press the buy button too fast. The solution was to remove some setText and image on the expressCheckoutFragment, but since there was some hardcoded values on the view, those values would show app. This PR, makes it so that the view appears empty.
This PR also adds mergePath for a lottie animation that is crashing on some devices (doesn’t fix the problem but it’s better to have it)

**Where should the reviewer start?**

ExternalBrowserRouter.java

**How should this be manually tested?**

  Disable browser, go to settings, press the telegram button, it should show a toast saying unknown error
 Buy oil, the inbetween screen should not have nothing on it
 Do a credit card transaction on buy gas, and check if the sucess animation breaks (except on the motorolla, that one it’s not fixed, the others is just fail safe as it should not break)

**What are the relevant tickets?**

https://aptoide.atlassian.net/browse/APPC-1189

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new libs, new keys, etc.)




**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass