### PR TITLE
[APPC-1194] Fixed onClick crash on balance in transaction activity

### DIFF
--- a/app/src/main/res/layout/activity_transaction_detail.xml
+++ b/app/src/main/res/layout/activity_transaction_detail.xml
@@ -6,7 +6,7 @@
     android:layout_height="match_parent"
     >
   <include
-      layout="@layout/layout_collapsing_app_bar"
+      layout="@layout/layout_appcoins_app_bar"
       android:layout_width="match_parent"
       android:layout_height="92dp"
       />
@@ -15,14 +15,14 @@
       android:id="@+id/src_img"
       android:layout_width="56dp"
       android:layout_height="56dp"
-      android:layout_marginBottom="@dimen/big_padding"
       android:layout_marginStart="@dimen/big_padding"
       android:layout_marginTop="@dimen/normal_margin"
+      android:layout_marginBottom="@dimen/big_padding"
+      android:animateLayoutChanges="true"
       android:background="@drawable/transaction_details_img_background"
       android:elevation="@dimen/component_elevation"
       app:layout_anchor="@+id/app_bar"
       app:layout_anchorGravity="center|bottom"
-      android:animateLayoutChanges="true"
       >
     <ImageView
         android:id="@+id/img"
@@ -39,9 +39,9 @@
   <androidx.core.widget.NestedScrollView
       android:layout_width="match_parent"
       android:layout_height="match_parent"
+      android:background="@drawable/background_fragment"
       android:fillViewport="true"
       app:layout_behavior="@string/appbar_scrolling_view_behavior"
-      android:background="@drawable/background_fragment"
       >
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
@@ -78,6 +78,7 @@
 
       <TextView
           android:id="@+id/amount"
+          style="@style/TransactionDetailsTextStyle.Heading"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
           android:layout_gravity="center"
@@ -85,44 +86,43 @@
           app:layout_constraintEnd_toEndOf="parent"
           app:layout_constraintStart_toStartOf="parent"
           app:layout_constraintTop_toTopOf="parent"
-          style="@style/TransactionDetailsTextStyle.Heading"
           />
 
       <TextView
           android:id="@+id/app_id"
+          style="@style/TransactionDetailsTextStyle.Title"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
           android:layout_marginTop="10dp"
           android:ellipsize="end"
           android:maxLines="1"
+          app:layout_constrainedWidth="true"
           app:layout_constraintEnd_toStartOf="@id/guideline_end"
           app:layout_constraintStart_toEndOf="@id/guideline_start"
           app:layout_constraintTop_toBottomOf="@id/amount"
-          app:layout_constrainedWidth="true"
-          style="@style/TransactionDetailsTextStyle.Title"
           />
 
       <TextView
           android:id="@+id/item_id"
+          style="@style/TransactionDetailsTextStyle.Subtitle"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
           android:ellipsize="end"
           android:maxLines="1"
           android:visibility="invisible"
+          app:layout_constrainedWidth="true"
           app:layout_constraintEnd_toStartOf="@id/guideline_end"
           app:layout_constraintStart_toEndOf="@id/guideline_start"
           app:layout_constraintTop_toBottomOf="@id/app_id"
-          app:layout_constrainedWidth="true"
-          style="@style/TransactionDetailsTextStyle.Subtitle"
           />
 
       <View
           android:id="@+id/top_separator"
           android:layout_width="match_parent"
           android:layout_height="1dp"
-          android:layout_marginEnd="32dp"
           android:layout_marginStart="32dp"
           android:layout_marginTop="32dp"
+          android:layout_marginEnd="32dp"
           android:background="#eaeaea"
           app:layout_constraintEnd_toEndOf="parent"
           app:layout_constraintStart_toStartOf="parent"
@@ -131,6 +131,7 @@
 
       <TextView
           android:id="@+id/status_label"
+          style="@style/TransactionDetailsTextStyle"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
           android:layout_marginStart="@dimen/half_large_margin"
@@ -138,11 +139,11 @@
           android:text="@string/transaction_status_label"
           app:layout_constraintStart_toStartOf="parent"
           app:layout_constraintTop_toBottomOf="@id/top_separator"
-          style="@style/TransactionDetailsTextStyle"
           />
 
       <TextView
           android:id="@+id/status"
+          style="@style/TransactionDetailsTextStyle.Content"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
           android:layout_marginEnd="@dimen/half_large_margin"
@@ -150,11 +151,11 @@
           android:textColor="@color/green"
           app:layout_constraintBottom_toBottomOf="@id/status_label"
           app:layout_constraintEnd_toEndOf="parent"
-          style="@style/TransactionDetailsTextStyle.Content"
           />
 
       <TextView
           android:id="@+id/category_label"
+          style="@style/TransactionDetailsTextStyle"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
           android:layout_marginStart="@dimen/half_large_margin"
@@ -162,18 +163,17 @@
           android:text="@string/transaction_category_label"
           app:layout_constraintStart_toStartOf="parent"
           app:layout_constraintTop_toBottomOf="@id/status_label"
-          style="@style/TransactionDetailsTextStyle"
           />
 
       <TextView
           android:id="@+id/category_name"
+          style="@style/TransactionDetailsTextStyle.Content"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
           android:layout_marginEnd="@dimen/half_large_margin"
           android:text="In App Purchase"
           app:layout_constraintBottom_toBottomOf="@id/category_label"
           app:layout_constraintEnd_toEndOf="parent"
-          style="@style/TransactionDetailsTextStyle.Content"
           />
 
       <FrameLayout
@@ -198,40 +198,40 @@
 
       <TextView
           android:id="@+id/to_label"
+          style="@style/TransactionDetailsTextStyle"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
           android:layout_marginStart="@dimen/half_large_margin"
           android:layout_marginTop="@dimen/big_margin"
           android:text="@string/transaction_to_label"
+          android:visibility="gone"
           app:layout_constraintStart_toStartOf="parent"
           app:layout_constraintTop_toBottomOf="@id/category_label"
-          style="@style/TransactionDetailsTextStyle"
-          android:visibility="gone"
           />
 
       <TextView
           android:id="@+id/to"
+          style="@style/TransactionDetailsTextStyle.Content.Address"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
           android:layout_marginEnd="@dimen/half_large_margin"
           android:singleLine="true"
           android:text="0xDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF"
+          android:visibility="gone"
+          app:layout_constrainedWidth="true"
           app:layout_constraintBottom_toBottomOf="@id/to_label"
           app:layout_constraintEnd_toEndOf="parent"
-          style="@style/TransactionDetailsTextStyle.Content.Address"
           app:layout_constraintHorizontal_bias="1.0"
           app:layout_constraintStart_toEndOf="@id/guideline_mid"
-          app:layout_constrainedWidth="true"
-          android:visibility="gone"
           />
 
       <View
           android:id="@+id/bottom_separator"
           android:layout_width="match_parent"
           android:layout_height="1dp"
-          android:layout_marginEnd="32dp"
           android:layout_marginStart="32dp"
           android:layout_marginTop="35dp"
+          android:layout_marginEnd="32dp"
           android:background="#eaeaea"
           app:layout_constraintEnd_toEndOf="parent"
           app:layout_constraintStart_toStartOf="parent"
@@ -240,6 +240,7 @@
 
       <TextView
           android:id="@+id/details_label"
+          style="@style/TransactionDetailsTextStyle.Dark"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
           android:layout_marginStart="@dimen/half_large_margin"
@@ -247,7 +248,6 @@
           android:text="@string/transaction_details_label"
           app:layout_constraintStart_toStartOf="parent"
           app:layout_constraintTop_toBottomOf="@id/bottom_separator"
-          style="@style/TransactionDetailsTextStyle.Dark"
           />
 
       <androidx.recyclerview.widget.RecyclerView
@@ -259,69 +259,70 @@
           android:clipToPadding="false"
           android:nestedScrollingEnabled="false"
           android:orientation="horizontal"
-          android:paddingEnd="@dimen/small_padding"
           android:paddingStart="@dimen/small_padding"
+          android:paddingEnd="@dimen/small_padding"
+          android:visibility="gone"
           app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
           app:layout_constraintEnd_toEndOf="parent"
           app:layout_constraintStart_toStartOf="parent"
           app:layout_constraintTop_toBottomOf="@id/details_label"
           app:layout_constraintVertical_bias="0.0"
-          android:visibility="gone"
           />
 
       <Button
           android:id="@+id/close_channel_btn"
+          style="@style/ButtonStyle.Light"
           android:layout_width="wrap_content"
           android:layout_height="32dp"
           android:layout_marginTop="@dimen/half_large_margin"
           android:text="@string/transaction_close_channel_btn_txt"
           android:visibility="gone"
+          app:layout_constraintBottom_toTopOf="@id/logo"
           app:layout_constraintEnd_toEndOf="parent"
           app:layout_constraintStart_toStartOf="parent"
           app:layout_constraintTop_toBottomOf="@+id/details_list"
           app:layout_constraintVertical_bias="1.0"
-          app:layout_constraintBottom_toTopOf="@id/logo"
-          style="@style/ButtonStyle.Light"
           />
 
       <Button
           android:id="@+id/more_detail"
+          style="@style/TransactionDetailsButtonStyle"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
           android:layout_gravity="center"
-          android:layout_marginTop="@dimen/big_margin"
           android:layout_marginStart="@dimen/half_large_margin"
+          android:layout_marginTop="@dimen/big_margin"
           android:layout_marginEnd="@dimen/half_large_margin"
           android:autoLink="web"
           android:clickable="true"
           android:linksClickable="true"
-          android:minHeight="36dp"
           android:minWidth="64dp"
+          android:minHeight="36dp"
           android:text="@string/transaction_details_label"
           app:layout_constraintEnd_toEndOf="parent"
           app:layout_constraintTop_toBottomOf="@id/bottom_separator"
-          style="@style/TransactionDetailsButtonStyle"
           />
 
       <ImageView
           android:id="@+id/logo"
           android:layout_width="16dp"
           android:layout_height="16dp"
-          android:layout_marginEnd="@dimen/normal_margin"
           android:layout_marginTop="40dp"
+          android:layout_marginEnd="@dimen/normal_margin"
+          android:layout_marginBottom="40dp"
           android:src="@drawable/ic_ether_logo"
-          app:layout_constraintEnd_toStartOf="@+id/brand"
-          app:layout_constraintEnd_toEndOf="parent"
+          app:layout_constrainedWidth="true"
           app:layout_constraintBottom_toBottomOf="parent"
+          app:layout_constraintEnd_toEndOf="parent"
+          app:layout_constraintEnd_toStartOf="@+id/brand"
           app:layout_constraintHorizontal_chainStyle="packed"
           app:layout_constraintStart_toStartOf="parent"
           app:layout_constraintTop_toBottomOf="@+id/close_channel_btn"
           app:layout_constraintVertical_bias="1.0"
-          app:layout_constrainedWidth="true"
-          android:layout_marginBottom="40dp"
           />
       <TextView
           android:id="@+id/brand"
+          style="@style/TransactionDetailsTextStyle.Footer"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
           android:singleLine="true"
@@ -331,7 +332,6 @@
           app:layout_constraintHorizontal_chainStyle="packed"
           app:layout_constraintStart_toEndOf="@+id/logo"
           app:layout_constraintTop_toTopOf="@id/logo"
-          style="@style/TransactionDetailsTextStyle.Footer"
           />
 
     </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/layout_appcoins_app_bar.xml
+++ b/app/src/main/res/layout/layout_appcoins_app_bar.xml
@@ -13,10 +13,6 @@
       android:layout_height="match_parent"
       android:background="@drawable/appbar_background_color"
       android:fitsSystemWindows="false"
-      app:collapsedTitleGravity="start|center_vertical"
-      app:collapsedTitleTextAppearance="@style/ToolbarTextAppearance.Title"
-      app:expandedTitleGravity="center"
-      app:expandedTitleTextAppearance="@style/ToolbarTextAppearance.Title.Expanded"
       app:layout_scrollFlags="scroll|exitUntilCollapsed"
       app:toolbarId="@+id/toolbar"
       >

--- a/app/src/main/res/layout/layout_appcoins_app_bar.xml
+++ b/app/src/main/res/layout/layout_appcoins_app_bar.xml
@@ -1,10 +1,10 @@
-<?xml version="1.0" encoding="utf-8"?>
 <com.google.android.material.appbar.AppBarLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/app_bar"
     android:layout_width="match_parent"
     android:layout_height="@dimen/app_bar_height"
+    android:theme="@style/AppTheme.AppBarOverlay"
     >
 
   <com.google.android.material.appbar.CollapsingToolbarLayout
@@ -20,46 +20,6 @@
       app:layout_scrollFlags="scroll|exitUntilCollapsed"
       app:toolbarId="@+id/toolbar"
       >
-
-    <TextView
-        android:id="@+id/toolbar_subtitle"
-        style="@style/TextAppearance.AppCompat.Body1.Roboto.Regular.Transparency"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center"
-        android:layout_marginTop="87dp"
-        android:layout_marginBottom="55dp"
-        android:ellipsize="end"
-        android:maxLines="1"
-        android:paddingStart="15dp"
-        android:paddingEnd="15dp"
-        app:layout_collapseMode="parallax"
-        />
-
-    <com.airbnb.lottie.LottieAnimationView
-        android:id="@+id/balance_skeleton"
-        android:layout_width="wrap_content"
-        android:layout_height="57dp"
-        android:layout_gravity="center"
-        android:layout_marginTop="15dp"
-        android:visibility="gone"
-        app:layout_collapseMode="parallax"
-        app:lottie_enableMergePathsForKitKatAndAbove="true"
-        app:lottie_loop="true"
-        app:lottie_rawRes="@raw/balance_skeleton"
-        />
-
-    <FrameLayout
-        android:id="@+id/empty_clickable_view"
-        android:layout_width="200dp"
-        android:layout_height="100dp"
-        android:layout_gravity="center"
-        android:layout_marginTop="50dp"
-        android:layout_marginBottom="55dp"
-        android:onClick="onClick"
-        android:visibility="gone"
-        />
-
     <androidx.appcompat.widget.Toolbar
         android:id="@+id/toolbar"
         android:layout_width="match_parent"


### PR DESCRIPTION
**What does this PR do?**

In some devices the app would crash if the user clicked on the balance due to the theme on the layout which would lead to the activity being casted to ContextThemeWrapper which doesn’t have the onClick method, this fixed that

**Where should the reviewer start?**

activity_transaction_detail.xml

**How should this be manually tested?**

Click on the balance and check if it goes to the balance screen.
Click on a transaction and check if transaction view has a back arrow

**What are the relevant tickets?**

 https://aptoide.atlassian.net/browse/APPC-1194

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new libs, new keys, etc.)




**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass