### PR TITLE
[bugfix/APPC-1193] Changed Poa logic to prevent multiple notifications for wallet validation if the user is already doing it

### DIFF
--- a/app/src/main/java/com/asfoundation/wallet/advertise/WalletPoAService.java
+++ b/app/src/main/java/com/asfoundation/wallet/advertise/WalletPoAService.java
@@ -102,9 +102,6 @@ public class WalletPoAService extends Service {
                 .doOnSuccess(requirementsStatus -> proofOfAttentionService.setChainId(packageName,
                     intent.getIntExtra(PARAM_NETWORK_ID, -1)))
                 .doOnSuccess(
-                    proofSubmissionFeeData -> proofOfAttentionService.setGasSettings(packageName,
-                        proofSubmissionFeeData.getGasPrice(), proofSubmissionFeeData.getGasLimit()))
-                .doOnSuccess(
                     requirementsStatus -> processWalletState(requirementsStatus.getStatus(),
                         intent)))
             .subscribe(requirementsStatus -> {

--- a/app/src/main/java/com/asfoundation/wallet/poa/Proof.java
+++ b/app/src/main/java/com/asfoundation/wallet/poa/Proof.java
@@ -1,6 +1,5 @@
 package com.asfoundation.wallet.poa;
 
-import java.math.BigDecimal;
 import java.util.Collections;
 import java.util.List;
 import javax.annotation.Nullable;
@@ -11,8 +10,6 @@ public class Proof {
   private final List<ProofComponent> proofComponentList;
   private final ProofStatus proofStatus;
   private final int chainId;
-  private final BigDecimal gasPrice;
-  private final BigDecimal gasLimit;
   @Nullable private final String countryCode;
   @Nullable private final String campaignId;
   @Nullable private final String oemAddress;
@@ -21,8 +18,8 @@ public class Proof {
 
   public Proof(String packageName, @Nullable String campaignId,
       List<ProofComponent> proofComponentList, String walletPackage, ProofStatus proofStatus,
-      int chainId, @Nullable String oemAddress, @Nullable String storeAddress, BigDecimal gasPrice,
-      BigDecimal gasLimit, @Nullable String hash, @Nullable String countryCode) {
+      int chainId, @Nullable String oemAddress, @Nullable String storeAddress,
+      @Nullable String hash, @Nullable String countryCode) {
     this.packageName = packageName;
     this.campaignId = campaignId;
     this.proofComponentList = proofComponentList;
@@ -31,23 +28,20 @@ public class Proof {
     this.chainId = chainId;
     this.oemAddress = oemAddress;
     this.storeAddress = storeAddress;
-    this.gasPrice = gasPrice;
-    this.gasLimit = gasLimit;
     this.hash = hash;
     this.countryCode = countryCode;
   }
 
   public Proof(String packageName, @Nullable String campaignId,
       List<ProofComponent> proofComponentList, String walletPackage, ProofStatus proofStatus,
-      int chainId, @Nullable String oemAddress, @Nullable String storeAddress, BigDecimal gasPrice,
-      BigDecimal gasLimit, String countryCode) {
+      int chainId, @Nullable String oemAddress, @Nullable String storeAddress, String countryCode) {
     this(packageName, campaignId, proofComponentList, walletPackage, proofStatus, chainId,
-        oemAddress, storeAddress, gasPrice, gasLimit, null, countryCode);
+        oemAddress, storeAddress, null, countryCode);
   }
 
   public Proof(String packageName, String walletPackage, ProofStatus proofStatus, int chainId) {
     this(packageName, null, Collections.emptyList(), walletPackage, proofStatus, chainId, null,
-        null, BigDecimal.ZERO, BigDecimal.ZERO, null, null);
+        null, null, null);
   }
 
   @Nullable public String getCountryCode() {
@@ -56,14 +50,6 @@ public class Proof {
 
   @Nullable public String getHash() {
     return hash;
-  }
-
-  public BigDecimal getGasPrice() {
-    return gasPrice;
-  }
-
-  public BigDecimal getGasLimit() {
-    return gasLimit;
   }
 
   public String getOemAddress() {
@@ -104,8 +90,6 @@ public class Proof {
     result = 31 * result + proofComponentList.hashCode();
     result = 31 * result + proofStatus.hashCode();
     result = 31 * result + chainId;
-    result = 31 * result + (gasPrice != null ? gasPrice.hashCode() : 0);
-    result = 31 * result + (gasLimit != null ? gasLimit.hashCode() : 0);
     result = 31 * result + (countryCode != null ? countryCode.hashCode() : 0);
     result = 31 * result + (campaignId != null ? campaignId.hashCode() : 0);
     result = 31 * result + (oemAddress != null ? oemAddress.hashCode() : 0);
@@ -125,8 +109,6 @@ public class Proof {
     if (!walletPackage.equals(proof.walletPackage)) return false;
     if (!proofComponentList.equals(proof.proofComponentList)) return false;
     if (proofStatus != proof.proofStatus) return false;
-    if (gasPrice != null ? !gasPrice.equals(proof.gasPrice) : proof.gasPrice != null) return false;
-    if (gasLimit != null ? !gasLimit.equals(proof.gasLimit) : proof.gasLimit != null) return false;
     if (countryCode != null ? !countryCode.equals(proof.countryCode) : proof.countryCode != null) {
       return false;
     }
@@ -157,16 +139,20 @@ public class Proof {
         + proofStatus
         + ", chainId="
         + chainId
-        + ", gasPrice="
-        + gasPrice
-        + ", gasLimit=" + gasLimit + ", countryCode='" + countryCode + '\''
+        + ", countryCode='"
+        + countryCode
+        + '\''
         + ", campaignId='"
         + campaignId
         + '\''
         + ", oemAddress='"
         + oemAddress
         + '\''
-        + ", storeAddress='" + storeAddress + '\'' + ", hash='" + hash
+        + ", storeAddress='"
+        + storeAddress
+        + '\''
+        + ", hash='"
+        + hash
         + '\''
         + '}';
   }

--- a/app/src/main/java/com/asfoundation/wallet/poa/ProofOfAttentionService.java
+++ b/app/src/main/java/com/asfoundation/wallet/poa/ProofOfAttentionService.java
@@ -16,6 +16,7 @@ import io.reactivex.subjects.Subject;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
+import org.apache.commons.lang3.StringUtils;
 
 public class ProofOfAttentionService {
   private final Repository<String, Proof> cache;
@@ -153,11 +154,13 @@ public class ProofOfAttentionService {
   private void setCampaignIdSync(String packageName, String campaignId) {
     synchronized (this) {
       Proof proof = getPreviousProofSync(packageName);
-      cache.saveSync(packageName,
-          new Proof(packageName, campaignId, proof.getProofComponentList(), walletPackage,
-              ProofStatus.PROCESSING, proof.getChainId(), proof.getOemAddress(),
-              proof.getStoreAddress(), proof.getGasPrice(), proof.getGasLimit(), proof.getHash(),
-              proof.getCountryCode()));
+      if (areComponentsMissing(proof) || StringUtils.isBlank(proof.getCampaignId())) {
+        cache.saveSync(packageName,
+            new Proof(packageName, campaignId, proof.getProofComponentList(), walletPackage,
+                ProofStatus.PROCESSING, proof.getChainId(), proof.getOemAddress(),
+                proof.getStoreAddress(), proof.getGasPrice(), proof.getGasLimit(), proof.getHash(),
+                proof.getCountryCode()));
+      }
     }
   }
 
@@ -169,11 +172,13 @@ public class ProofOfAttentionService {
   private void setChainIdSync(String packageName, int chainId) {
     synchronized (this) {
       Proof proof = getPreviousProofSync(packageName);
-      cache.saveSync(packageName,
-          new Proof(packageName, proof.getCampaignId(), proof.getProofComponentList(),
-              walletPackage, ProofStatus.PROCESSING, chainId, proof.getOemAddress(),
-              proof.getStoreAddress(), proof.getGasPrice(), proof.getGasLimit(), proof.getHash(),
-              proof.getCountryCode()));
+      if (areComponentsMissing(proof) && proof.getChainId() <= 0) {
+        cache.saveSync(packageName,
+            new Proof(packageName, proof.getCampaignId(), proof.getProofComponentList(),
+                walletPackage, ProofStatus.PROCESSING, chainId, proof.getOemAddress(),
+                proof.getStoreAddress(), proof.getGasPrice(), proof.getGasLimit(), proof.getHash(),
+                proof.getCountryCode()));
+      }
     }
   }
 
@@ -325,22 +330,28 @@ public class ProofOfAttentionService {
   private void setOemAddressSync(String packageName, String address) {
     synchronized (this) {
       Proof proof = getPreviousProofSync(packageName);
-      cache.saveSync(packageName,
-          new Proof(packageName, proof.getCampaignId(), proof.getProofComponentList(),
-              walletPackage, ProofStatus.PROCESSING, proof.getChainId(), address,
-              proof.getStoreAddress(), proof.getGasPrice(), proof.getGasLimit(), proof.getHash(),
-              proof.getCountryCode()));
+      if (areComponentsMissing(proof) || StringUtils.isBlank(proof.getOemAddress())) {
+        cache.saveSync(packageName,
+            new Proof(packageName, proof.getCampaignId(), proof.getProofComponentList(),
+                walletPackage, ProofStatus.PROCESSING, proof.getChainId(), address,
+                proof.getStoreAddress(), proof.getGasPrice(), proof.getGasLimit(), proof.getHash(),
+                proof.getCountryCode()));
+      }
     }
   }
 
   private void setGasSettingsSync(String packageName, BigDecimal gasPrice, BigDecimal gasLimit) {
     synchronized (this) {
       Proof proof = getPreviousProofSync(packageName);
-      cache.saveSync(packageName,
-          new Proof(packageName, proof.getCampaignId(), proof.getProofComponentList(),
-              walletPackage, ProofStatus.PROCESSING, proof.getChainId(), proof.getOemAddress(),
-              proof.getStoreAddress(), gasPrice, gasLimit, proof.getHash(),
-              proof.getCountryCode()));
+      if (areComponentsMissing(proof)
+          || proof.getGasLimit() == null
+          || proof.getGasPrice() == null) {
+        cache.saveSync(packageName,
+            new Proof(packageName, proof.getCampaignId(), proof.getProofComponentList(),
+                walletPackage, ProofStatus.PROCESSING, proof.getChainId(), proof.getOemAddress(),
+                proof.getStoreAddress(), gasPrice, gasLimit, proof.getHash(),
+                proof.getCountryCode()));
+      }
     }
   }
 
@@ -355,11 +366,13 @@ public class ProofOfAttentionService {
   private void setStoreAddressSync(String packageName, String address) {
     synchronized (this) {
       Proof proof = getPreviousProofSync(packageName);
-      cache.saveSync(packageName,
-          new Proof(packageName, proof.getCampaignId(), proof.getProofComponentList(),
-              walletPackage, ProofStatus.PROCESSING, proof.getChainId(), proof.getOemAddress(),
-              address, proof.getGasPrice(), proof.getGasLimit(), proof.getHash(),
-              proof.getCountryCode()));
+      if (areComponentsMissing(proof) || StringUtils.isBlank(proof.getStoreAddress())) {
+        cache.saveSync(packageName,
+            new Proof(packageName, proof.getCampaignId(), proof.getProofComponentList(),
+                walletPackage, ProofStatus.PROCESSING, proof.getChainId(), proof.getOemAddress(),
+                address, proof.getGasPrice(), proof.getGasLimit(), proof.getHash(),
+                proof.getCountryCode()));
+      }
     }
   }
 

--- a/app/src/main/java/com/asfoundation/wallet/poa/ProofOfAttentionService.java
+++ b/app/src/main/java/com/asfoundation/wallet/poa/ProofOfAttentionService.java
@@ -13,7 +13,6 @@ import io.reactivex.Single;
 import io.reactivex.disposables.CompositeDisposable;
 import io.reactivex.subjects.BehaviorSubject;
 import io.reactivex.subjects.Subject;
-import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.commons.lang3.StringUtils;
@@ -89,8 +88,7 @@ public class ProofOfAttentionService {
       cache.saveSync(packageName,
           new Proof(packageName, proof.getCampaignId(), proof.getProofComponentList(),
               walletPackage, ProofStatus.PROCESSING, proof.getChainId(), proof.getOemAddress(),
-              proof.getStoreAddress(), proof.getGasPrice(), proof.getGasLimit(), proof.getHash(),
-              countryCode));
+              proof.getStoreAddress(), proof.getHash(), countryCode));
     }
   }
 
@@ -129,14 +127,14 @@ public class ProofOfAttentionService {
     Proof completedProof =
         new Proof(proof.getPackageName(), proof.getCampaignId(), proof.getProofComponentList(),
             proof.getWalletPackage(), ProofStatus.SUBMITTING, proof.getChainId(),
-            proof.getOemAddress(), proof.getStoreAddress(), proof.getGasPrice(),
-            proof.getGasLimit(), proof.getHash(), proof.getCountryCode());
+            proof.getOemAddress(), proof.getStoreAddress(), proof.getHash(),
+            proof.getCountryCode());
     return proofWriter.writeProof(completedProof)
         .doOnSuccess(hash -> cache.saveSync(completedProof.getPackageName(),
             new Proof(completedProof.getPackageName(), completedProof.getCampaignId(),
                 completedProof.getProofComponentList(), walletPackage, ProofStatus.COMPLETED,
-                proof.getChainId(), proof.getOemAddress(), proof.getStoreAddress(),
-                proof.getGasPrice(), proof.getGasLimit(), hash, proof.getCountryCode())));
+                proof.getChainId(), proof.getOemAddress(), proof.getStoreAddress(), hash,
+                proof.getCountryCode())));
   }
 
   public void stop() {
@@ -158,8 +156,7 @@ public class ProofOfAttentionService {
         cache.saveSync(packageName,
             new Proof(packageName, campaignId, proof.getProofComponentList(), walletPackage,
                 ProofStatus.PROCESSING, proof.getChainId(), proof.getOemAddress(),
-                proof.getStoreAddress(), proof.getGasPrice(), proof.getGasLimit(), proof.getHash(),
-                proof.getCountryCode()));
+                proof.getStoreAddress(), proof.getHash(), proof.getCountryCode()));
       }
     }
   }
@@ -176,8 +173,7 @@ public class ProofOfAttentionService {
         cache.saveSync(packageName,
             new Proof(packageName, proof.getCampaignId(), proof.getProofComponentList(),
                 walletPackage, ProofStatus.PROCESSING, chainId, proof.getOemAddress(),
-                proof.getStoreAddress(), proof.getGasPrice(), proof.getGasLimit(), proof.getHash(),
-                proof.getCountryCode()));
+                proof.getStoreAddress(), proof.getHash(), proof.getCountryCode()));
       }
     }
   }
@@ -188,8 +184,7 @@ public class ProofOfAttentionService {
       cache.saveSync(packageName,
           new Proof(packageName, proof.getCampaignId(), proof.getProofComponentList(),
               walletPackage, proofStatus, proof.getChainId(), proof.getOemAddress(),
-              proof.getStoreAddress(), proof.getGasPrice(), proof.getGasLimit(), proof.getHash(),
-              proof.getCountryCode()));
+              proof.getStoreAddress(), proof.getHash(), proof.getCountryCode()));
     }
   }
 
@@ -198,8 +193,8 @@ public class ProofOfAttentionService {
       Proof proof = getPreviousProofSync(packageName);
       cache.saveSync(packageName, new Proof(proof.getPackageName(), proof.getCampaignId(),
           createProofComponentList(timeStamp, nonce, proof), walletPackage, ProofStatus.PROCESSING,
-          proof.getChainId(), proof.getOemAddress(), proof.getStoreAddress(), proof.getGasPrice(),
-          proof.getGasLimit(), proof.getHash(), proof.getCountryCode()));
+          proof.getChainId(), proof.getOemAddress(), proof.getStoreAddress(), proof.getHash(),
+          proof.getCountryCode()));
     }
   }
 
@@ -304,17 +299,6 @@ public class ProofOfAttentionService {
         .size() < maxNumberProofComponents;
   }
 
-  private boolean areGasSettingsTheSame(BigDecimal gasPrice, BigDecimal gasLimit, Proof proof) {
-    return (proof.getGasPrice() == null && gasPrice != null) || (proof.getGasLimit() == null
-        && gasLimit != null) || (proof.getGasLimit() != null
-        && gasLimit != null
-        && proof.getGasLimit()
-        .compareTo(gasLimit) == 0) || (proof.getGasPrice() != null
-        && gasPrice != null
-        && proof.getGasPrice()
-        .compareTo(gasPrice) == 0);
-  }
-
   public Observable<List<Proof>> get() {
     return cache.getAll();
   }
@@ -345,21 +329,7 @@ public class ProofOfAttentionService {
         cache.saveSync(packageName,
             new Proof(packageName, proof.getCampaignId(), proof.getProofComponentList(),
                 walletPackage, ProofStatus.PROCESSING, proof.getChainId(), address,
-                proof.getStoreAddress(), proof.getGasPrice(), proof.getGasLimit(), proof.getHash(),
-                proof.getCountryCode()));
-      }
-    }
-  }
-
-  private void setGasSettingsSync(String packageName, BigDecimal gasPrice, BigDecimal gasLimit) {
-    synchronized (this) {
-      Proof proof = getPreviousProofSync(packageName);
-      if (areComponentsMissing(proof) || areGasSettingsTheSame(gasPrice, gasLimit, proof)) {
-        cache.saveSync(packageName,
-            new Proof(packageName, proof.getCampaignId(), proof.getProofComponentList(),
-                walletPackage, ProofStatus.PROCESSING, proof.getChainId(), proof.getOemAddress(),
-                proof.getStoreAddress(), gasPrice, gasLimit, proof.getHash(),
-                proof.getCountryCode()));
+                proof.getStoreAddress(), proof.getHash(), proof.getCountryCode()));
       }
     }
   }
@@ -375,12 +345,11 @@ public class ProofOfAttentionService {
   private void setStoreAddressSync(String packageName, String address) {
     synchronized (this) {
       Proof proof = getPreviousProofSync(packageName);
-      if (areComponentsMissing(proof) || StringUtils.isBlank(proof.getStoreAddress())) {
+      if (areComponentsMissing(proof) || StringUtils.equals(proof.getStoreAddress(), address)) {
         cache.saveSync(packageName,
             new Proof(packageName, proof.getCampaignId(), proof.getProofComponentList(),
                 walletPackage, ProofStatus.PROCESSING, proof.getChainId(), proof.getOemAddress(),
-                address, proof.getGasPrice(), proof.getGasLimit(), proof.getHash(),
-                proof.getCountryCode()));
+                address, proof.getHash(), proof.getCountryCode()));
       }
     }
   }
@@ -392,12 +361,6 @@ public class ProofOfAttentionService {
         return proofWriter.hasWalletPrepared(chainId, packageName, versionCode);
       }
     });
-  }
-
-  public void setGasSettings(String packageName, BigDecimal gasPrice, BigDecimal gasLimit) {
-    disposables.add(packageName,
-        Completable.fromAction(() -> setGasSettingsSync(packageName, gasPrice, gasLimit))
-            .subscribe());
   }
 
   public Single<Wallet> handleCreateWallet() {

--- a/app/src/main/java/com/asfoundation/wallet/poa/ProofSubmissionFeeData.java
+++ b/app/src/main/java/com/asfoundation/wallet/poa/ProofSubmissionFeeData.java
@@ -1,25 +1,10 @@
 package com.asfoundation.wallet.poa;
 
-import java.math.BigDecimal;
-
 public class ProofSubmissionFeeData {
-  private final BigDecimal gasLimit;
-  private final BigDecimal gasPrice;
   private final RequirementsStatus status;
 
-  public ProofSubmissionFeeData(RequirementsStatus status, BigDecimal gasLimit,
-      BigDecimal gasPrice) {
-    this.gasLimit = gasLimit;
-    this.gasPrice = gasPrice;
+  public ProofSubmissionFeeData(RequirementsStatus status) {
     this.status = status;
-  }
-
-  public BigDecimal getGasLimit() {
-    return gasLimit;
-  }
-
-  public BigDecimal getGasPrice() {
-    return gasPrice;
   }
 
   public RequirementsStatus getStatus() {
@@ -27,10 +12,7 @@ public class ProofSubmissionFeeData {
   }
 
   @Override public int hashCode() {
-    int result = getGasLimit().hashCode();
-    result = 31 * result + getGasPrice().hashCode();
-    result = 31 * result + getStatus().hashCode();
-    return result;
+    return getStatus().hashCode();
   }
 
   @Override public boolean equals(Object o) {
@@ -39,8 +21,6 @@ public class ProofSubmissionFeeData {
 
     ProofSubmissionFeeData that = (ProofSubmissionFeeData) o;
 
-    if (!getGasLimit().equals(that.getGasLimit())) return false;
-    if (!getGasPrice().equals(that.getGasPrice())) return false;
     return getStatus() == that.getStatus();
   }
 

--- a/app/src/main/java/com/asfoundation/wallet/repository/BdsBackEndWriter.kt
+++ b/app/src/main/java/com/asfoundation/wallet/repository/BdsBackEndWriter.kt
@@ -8,7 +8,6 @@ import com.asfoundation.wallet.poa.ProofWriter
 import com.asfoundation.wallet.service.CampaignService
 import com.asfoundation.wallet.service.CampaignStatus
 import io.reactivex.Single
-import java.math.BigDecimal
 import java.net.UnknownHostException
 
 open class BdsBackEndWriter(
@@ -26,12 +25,10 @@ open class BdsBackEndWriter(
     if (!isCorrectNetwork(chainId)) {
       return if (isKnownNetwork(chainId)) {
         Single.just(
-            ProofSubmissionFeeData(ProofSubmissionFeeData.RequirementsStatus.WRONG_NETWORK,
-                BigDecimal.ZERO, BigDecimal.ZERO))
+            ProofSubmissionFeeData(ProofSubmissionFeeData.RequirementsStatus.WRONG_NETWORK))
       } else {
         Single.just(
-            ProofSubmissionFeeData(ProofSubmissionFeeData.RequirementsStatus.UNKNOWN_NETWORK,
-                BigDecimal.ZERO, BigDecimal.ZERO))
+            ProofSubmissionFeeData(ProofSubmissionFeeData.RequirementsStatus.UNKNOWN_NETWORK))
       }
     }
 
@@ -43,25 +40,20 @@ open class BdsBackEndWriter(
         .map {
           if (isAvailable(it.campaignStatus)) {
             if (isEligible(it.campaignStatus)) {
-              ProofSubmissionFeeData(ProofSubmissionFeeData.RequirementsStatus.READY,
-                  BigDecimal.ZERO, BigDecimal.ZERO)
+              ProofSubmissionFeeData(ProofSubmissionFeeData.RequirementsStatus.READY)
             } else {
-              ProofSubmissionFeeData(ProofSubmissionFeeData.RequirementsStatus.NOT_ELIGIBLE,
-                  BigDecimal.ZERO, BigDecimal.ZERO)
+              ProofSubmissionFeeData(ProofSubmissionFeeData.RequirementsStatus.NOT_ELIGIBLE)
             }
           } else {
-            ProofSubmissionFeeData(ProofSubmissionFeeData.RequirementsStatus.NOT_AVAILABLE,
-                BigDecimal.ZERO, BigDecimal.ZERO)
+            ProofSubmissionFeeData(ProofSubmissionFeeData.RequirementsStatus.NOT_AVAILABLE)
           }
         }
         .onErrorReturn {
           when (it) {
             is WalletNotFoundException -> ProofSubmissionFeeData(
-                ProofSubmissionFeeData.RequirementsStatus.NO_WALLET,
-                BigDecimal.ZERO, BigDecimal.ZERO)
+                ProofSubmissionFeeData.RequirementsStatus.NO_WALLET)
             is UnknownHostException -> ProofSubmissionFeeData(
-                ProofSubmissionFeeData.RequirementsStatus.NO_NETWORK,
-                BigDecimal.ZERO, BigDecimal.ZERO)
+                ProofSubmissionFeeData.RequirementsStatus.NO_NETWORK)
             else -> throw it
           }
         }

--- a/app/src/test/java/com/asfoundation/wallet/poa/ProofOfAttentionServiceTest.java
+++ b/app/src/test/java/com/asfoundation/wallet/poa/ProofOfAttentionServiceTest.java
@@ -16,7 +16,6 @@ import io.reactivex.disposables.CompositeDisposable;
 import io.reactivex.observers.TestObserver;
 import io.reactivex.schedulers.TestScheduler;
 import io.reactivex.subjects.BehaviorSubject;
-import java.math.BigDecimal;
 import java.net.UnknownHostException;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
@@ -105,7 +104,7 @@ public class ProofOfAttentionServiceTest {
         .assertValueCount(1)
         .assertValue(
             new Proof(packageName, campaignId, Collections.emptyList(), BuildConfig.APPLICATION_ID,
-                ProofStatus.PROCESSING, 1, null, null, BigDecimal.ZERO, BigDecimal.ZERO, null));
+                ProofStatus.PROCESSING, 1, null, null, null));
   }
 
   @Test public void registerProof() {
@@ -123,7 +122,7 @@ public class ProofOfAttentionServiceTest {
     testObserver.assertNoErrors()
         .assertValueCount(1)
         .assertValue(new Proof(packageName, campaignId, Collections.emptyList(), walletPackage,
-            ProofStatus.PROCESSING, 1, null, null, BigDecimal.ZERO, BigDecimal.ZERO, null));
+            ProofStatus.PROCESSING, 1, null, null, null));
 
     proofOfAttentionService.registerProof(packageName, timeStamp);
 
@@ -134,7 +133,7 @@ public class ProofOfAttentionServiceTest {
             .values()
             .get(1),
         new Proof(packageName, campaignId, proofComponents, walletPackage, ProofStatus.PROCESSING,
-            1, null, null, BigDecimal.ZERO, BigDecimal.ZERO, null));
+            1, null, null, null));
 
     proofOfAttentionService.registerProof(packageName, timeStamp2);
     testScheduler.triggerActions();
@@ -144,7 +143,7 @@ public class ProofOfAttentionServiceTest {
             .values()
             .get(2),
         new Proof(packageName, campaignId, proofComponents, walletPackage, ProofStatus.PROCESSING,
-            1, null, null, BigDecimal.ZERO, BigDecimal.ZERO, null));
+            1, null, null, null));
   }
 
   @Test public void registerProofWithoutCampaignId() {
@@ -164,7 +163,7 @@ public class ProofOfAttentionServiceTest {
             .values()
             .get(0),
         new Proof(packageName, null, proofComponents, walletPackage, ProofStatus.PROCESSING, 1,
-            null, null, BigDecimal.ZERO, BigDecimal.ZERO, null));
+            null, null, null));
   }
 
   @Test public void registerProofMaxComponents() {
@@ -212,13 +211,12 @@ public class ProofOfAttentionServiceTest {
         .get(6);
     verify(campaignService, times(1)).submitProof(
         new Proof(value.getPackageName(), value.getCampaignId(), value.getProofComponentList(),
-            value.getWalletPackage(), ProofStatus.SUBMITTING, 1, null, null, BigDecimal.ZERO,
-            BigDecimal.ZERO, null, "PT"), wallet);
+            value.getWalletPackage(), ProofStatus.SUBMITTING, 1, null, null, null, "PT"), wallet);
 
     Assert.assertEquals(
         new Proof(value.getPackageName(), value.getCampaignId(), value.getProofComponentList(),
-            value.getWalletPackage(), ProofStatus.COMPLETED, 1, null, null, BigDecimal.ZERO,
-            BigDecimal.ZERO, SUBMIT_HASH, "PT"), value);
+            value.getWalletPackage(), ProofStatus.COMPLETED, 1, null, null, SUBMIT_HASH, "PT"),
+        value);
 
     proofOfAttentionService.stop();
   }
@@ -311,7 +309,7 @@ public class ProofOfAttentionServiceTest {
         .assertValueCount(1)
         .assertValue(
             new Proof(packageName, null, Collections.emptyList(), BuildConfig.APPLICATION_ID,
-                ProofStatus.PROCESSING, 2, null, null, BigDecimal.ZERO, BigDecimal.ZERO, null));
+                ProofStatus.PROCESSING, 2, null, null, null));
   }
 
   @Test public void isWalletReady() {
@@ -320,8 +318,7 @@ public class ProofOfAttentionServiceTest {
             .subscribeOn(testScheduler)
             .test();
     ProofSubmissionFeeData readyFee =
-        new ProofSubmissionFeeData(ProofSubmissionFeeData.RequirementsStatus.READY, BigDecimal.ZERO,
-            BigDecimal.ZERO);
+        new ProofSubmissionFeeData(ProofSubmissionFeeData.RequirementsStatus.READY);
     hasWallet.onNext(new Wallet(wallet));
     testScheduler.triggerActions();
     ready.assertComplete()
@@ -335,8 +332,7 @@ public class ProofOfAttentionServiceTest {
             .subscribeOn(testScheduler)
             .test();
     ProofSubmissionFeeData noWalletFee =
-        new ProofSubmissionFeeData(ProofSubmissionFeeData.RequirementsStatus.NO_WALLET,
-            BigDecimal.ZERO, BigDecimal.ZERO);
+        new ProofSubmissionFeeData(ProofSubmissionFeeData.RequirementsStatus.NO_WALLET);
     hasWallet.onError(new WalletNotFoundException());
     testScheduler.triggerActions();
     noWallet.assertComplete()
@@ -352,8 +348,7 @@ public class ProofOfAttentionServiceTest {
             .subscribeOn(testScheduler)
             .test();
     ProofSubmissionFeeData noFundsFee =
-        new ProofSubmissionFeeData(ProofSubmissionFeeData.RequirementsStatus.NOT_ELIGIBLE,
-            BigDecimal.ZERO, BigDecimal.ZERO);
+        new ProofSubmissionFeeData(ProofSubmissionFeeData.RequirementsStatus.NOT_ELIGIBLE);
     hasWallet.onNext(new Wallet(wallet));
     testScheduler.triggerActions();
     noFunds.assertComplete()
@@ -369,8 +364,7 @@ public class ProofOfAttentionServiceTest {
             .subscribeOn(testScheduler)
             .test();
     ProofSubmissionFeeData noFundsFee =
-        new ProofSubmissionFeeData(ProofSubmissionFeeData.RequirementsStatus.NOT_AVAILABLE,
-            BigDecimal.ZERO, BigDecimal.ZERO);
+        new ProofSubmissionFeeData(ProofSubmissionFeeData.RequirementsStatus.NOT_AVAILABLE);
     hasWallet.onNext(new Wallet(wallet));
     testScheduler.triggerActions();
     noFunds.assertComplete()
@@ -384,8 +378,7 @@ public class ProofOfAttentionServiceTest {
             .subscribeOn(testScheduler)
             .test();
     ProofSubmissionFeeData noFundsFee =
-        new ProofSubmissionFeeData(ProofSubmissionFeeData.RequirementsStatus.NO_NETWORK,
-            BigDecimal.ZERO, BigDecimal.ZERO);
+        new ProofSubmissionFeeData(ProofSubmissionFeeData.RequirementsStatus.NO_NETWORK);
     hasWallet.onError(new UnknownHostException());
     testScheduler.triggerActions();
     noFunds.assertComplete()
@@ -401,8 +394,7 @@ public class ProofOfAttentionServiceTest {
             .subscribeOn(testScheduler)
             .test();
     ProofSubmissionFeeData wrongNetwork =
-        new ProofSubmissionFeeData(ProofSubmissionFeeData.RequirementsStatus.WRONG_NETWORK,
-            BigDecimal.ZERO, BigDecimal.ZERO);
+        new ProofSubmissionFeeData(ProofSubmissionFeeData.RequirementsStatus.WRONG_NETWORK);
     hasWallet.onError(new UnknownHostException());
     testScheduler.triggerActions();
     noFunds.assertComplete()
@@ -416,8 +408,7 @@ public class ProofOfAttentionServiceTest {
             .subscribeOn(testScheduler)
             .test();
     ProofSubmissionFeeData wrongNetwork =
-        new ProofSubmissionFeeData(ProofSubmissionFeeData.RequirementsStatus.UNKNOWN_NETWORK,
-            BigDecimal.ZERO, BigDecimal.ZERO);
+        new ProofSubmissionFeeData(ProofSubmissionFeeData.RequirementsStatus.UNKNOWN_NETWORK);
     hasWallet.onError(new UnknownHostException());
     testScheduler.triggerActions();
     noFunds.assertComplete()


### PR DESCRIPTION

**What does this PR do?**

   This PR aims to fix another verification notification to popup when the user is already in the validation process

**Database changed?**

   No

**Where should the reviewer start?**

- [x] ProofOfAttentionService.java

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [APPC-1193](https://aptoide.atlassian.net/browse/APPC-1193)

**What are the relevant tickets?**

  Tickets related to this pull-request: [APPC-1193](https://aptoide.atlassian.net/browse/APPC-1193)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new libs, new keys, etc.)




**Code Review Checklist**

- [x] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [x] Remove comments & unused code & forgotten testing Logs
- [x] Codestyle
- [ ] Functional QA tests pass