### PR TITLE
[bugfix/APPC-1215] Verification activity remaining in background fix

### DIFF
--- a/app/src/main/java/com/asfoundation/wallet/wallet_validation/WalletValidationActivity.kt
+++ b/app/src/main/java/com/asfoundation/wallet/wallet_validation/WalletValidationActivity.kt
@@ -27,12 +27,12 @@ class WalletValidationActivity : BaseActivity(), WalletValidationView {
   }
 
   override fun onBackPressed() {
-    close()
+    finish()
     super.onBackPressed()
   }
 
   override fun close() {
-    finish()
+    finishAndRemoveTask()
   }
 
   override fun showPhoneValidationView(countryCode: String?, phoneNumber: String?,


### PR DESCRIPTION
**What does this PR do?**

   The wallet verification activity no longer stays in background when the user cancels it or finishes it.
It still remains if the user presses back

**Database changed?**

 No

**Where should the reviewer start?**

WalletValidationActivity.java

**How should this be manually tested?**

See if the description really happens

**What are the relevant tickets?**

https://aptoide.atlassian.net/browse/APPC-1215


**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass