### PR TITLE
[APPC-1089] TopUp no feedback on screen rotation

### DIFF
--- a/app/src/main/java/com/asfoundation/wallet/topup/TopUpActivity.kt
+++ b/app/src/main/java/com/asfoundation/wallet/topup/TopUpActivity.kt
@@ -2,6 +2,7 @@ package com.asfoundation.wallet.topup
 
 import android.content.Context
 import android.content.Intent
+import android.content.pm.ActivityInfo
 import android.net.Uri
 import android.os.Bundle
 import android.view.MenuItem
@@ -136,5 +137,9 @@ class TopUpActivity : BaseActivity(), TopUpActivityView, ToolbarManager, UriNavi
 
   override fun uriResults(): Observable<Uri> {
     return results
+  }
+
+  override fun lockOrientation() {
+    requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_LOCKED
   }
 }

--- a/app/src/main/java/com/asfoundation/wallet/topup/TopUpActivity.kt
+++ b/app/src/main/java/com/asfoundation/wallet/topup/TopUpActivity.kt
@@ -112,6 +112,7 @@ class TopUpActivity : BaseActivity(), TopUpActivityView, ToolbarManager, UriNavi
                 data.getBoolean(
                     VALID_BONUS)), TopUpSuccessFragment::class.java.simpleName)
         .commit()
+    unlockRotation()
   }
 
   override fun close() {
@@ -137,6 +138,10 @@ class TopUpActivity : BaseActivity(), TopUpActivityView, ToolbarManager, UriNavi
 
   override fun uriResults(): Observable<Uri> {
     return results
+  }
+
+  override fun unlockRotation() {
+    requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED
   }
 
   override fun lockOrientation() {

--- a/app/src/main/java/com/asfoundation/wallet/topup/TopUpActivityView.kt
+++ b/app/src/main/java/com/asfoundation/wallet/topup/TopUpActivityView.kt
@@ -20,4 +20,6 @@ interface TopUpActivityView {
   fun acceptResult(uri: Uri)
 
   fun showToolbar()
+
+  fun lockOrientation()
 }

--- a/app/src/main/java/com/asfoundation/wallet/topup/TopUpActivityView.kt
+++ b/app/src/main/java/com/asfoundation/wallet/topup/TopUpActivityView.kt
@@ -22,4 +22,6 @@ interface TopUpActivityView {
   fun showToolbar()
 
   fun lockOrientation()
+
+  fun unlockRotation()
 }

--- a/app/src/main/java/com/asfoundation/wallet/topup/payment/PaymentAuthFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/topup/payment/PaymentAuthFragment.kt
@@ -277,6 +277,11 @@ class PaymentAuthFragment : DaggerFragment(), PaymentAuthView {
     change_card_button.visibility = View.INVISIBLE
   }
 
+  override fun showFinishingLoading() {
+    topUpView?.lockOrientation()
+    showLoading()
+  }
+
   override fun hideLoading() {
     loading.visibility = View.GONE
     button.isEnabled = fragment_braintree_credit_card_form.isValid

--- a/app/src/main/java/com/asfoundation/wallet/topup/payment/PaymentAuthFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/topup/payment/PaymentAuthFragment.kt
@@ -311,6 +311,7 @@ class PaymentAuthFragment : DaggerFragment(), PaymentAuthView {
   override fun showNetworkError() {
     if (!networkErrorDialog.isShowing) {
       networkErrorDialog.show()
+      topUpView?.unlockRotation()
     }
   }
 
@@ -370,6 +371,7 @@ class PaymentAuthFragment : DaggerFragment(), PaymentAuthView {
   override fun showGenericError() {
     if (!genericErrorDialog.isShowing) {
       genericErrorDialog.show()
+      topUpView?.unlockRotation()
     }
   }
 

--- a/app/src/main/java/com/asfoundation/wallet/topup/payment/PaymentAuthPresenter.java
+++ b/app/src/main/java/com/asfoundation/wallet/topup/payment/PaymentAuthPresenter.java
@@ -145,7 +145,7 @@ public class PaymentAuthPresenter {
 
   private void onViewCreatedCompletePayment(String transactionOrigin, CurrencyData currencyData,
       String selectedCurrency, String currency, String transactionType) {
-    disposables.add(Completable.fromAction(() -> view.showLoading())
+    disposables.add(Completable.fromAction(() -> view.showFinishingLoading())
         .observeOn(networkScheduler)
         .andThen(convertAmount(currencyData, selectedCurrency).flatMapCompletable(
             value -> billingService.getAuthorization(transactionOrigin, value, currency,

--- a/app/src/main/java/com/asfoundation/wallet/topup/payment/PaymentAuthPresenter.java
+++ b/app/src/main/java/com/asfoundation/wallet/topup/payment/PaymentAuthPresenter.java
@@ -145,7 +145,7 @@ public class PaymentAuthPresenter {
 
   private void onViewCreatedCompletePayment(String transactionOrigin, CurrencyData currencyData,
       String selectedCurrency, String currency, String transactionType) {
-    disposables.add(Completable.fromAction(() -> view.showFinishingLoading())
+    disposables.add(Completable.fromAction(() -> view.showLoading())
         .observeOn(networkScheduler)
         .andThen(convertAmount(currencyData, selectedCurrency).flatMapCompletable(
             value -> billingService.getAuthorization(transactionOrigin, value, currency,
@@ -243,7 +243,7 @@ public class PaymentAuthPresenter {
 
   private void handlePaymentMethodResults() {
     disposables.add(view.paymentMethodDetailsEvent()
-        .doOnNext(__ -> view.showLoading())
+        .doOnNext(__ -> view.showFinishingLoading())
         .flatMapCompletable(adyen::finishPayment)
         .observeOn(viewScheduler)
         .subscribe(() -> {

--- a/app/src/main/java/com/asfoundation/wallet/topup/payment/PaymentAuthView.kt
+++ b/app/src/main/java/com/asfoundation/wallet/topup/payment/PaymentAuthView.kt
@@ -11,6 +11,8 @@ interface PaymentAuthView {
 
   fun showLoading()
 
+  fun showFinishingLoading()
+
   fun hideLoading()
 
   fun errorDismisses(): Observable<Any>


### PR DESCRIPTION
**What does this PR do?**

   Locks screen rotation after the user begins the adyen transaction so that he always receives the proper feedback.

**Database changed?**

No

**Where should the reviewer start?**

PaymentAuthFragment.java

**How should this be manually tested?**

https://aptoide.atlassian.net/browse/APPC-1089

**What are the relevant tickets?**

https://aptoide.atlassian.net/browse/APPC-1089


**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass