### PR TITLE
Feature/appc 1232 use already existent transaction to proceed with purchase

### DIFF
--- a/app/src/main/java/com/asfoundation/wallet/billing/adyen/AdyenBillingService.kt
+++ b/app/src/main/java/com/asfoundation/wallet/billing/adyen/AdyenBillingService.kt
@@ -113,7 +113,8 @@ class AdyenBillingService(
                       TransactionType.valueOf(type),
                       TransactionStatus.PENDING_SERVICE_AUTHORIZATION, Gateway.Name.adyen)
                       .flatMap {
-                        if (it.status != Transaction.Status.INVALID_TRANSACTION) {
+                        if (it.status != Transaction.Status.INVALID_TRANSACTION && it.gateway?.name == Gateway.Name.adyen) {
+                          //TODO REMOVE t.gateway?.name == Gateway.Name.appcoins_credits
                           this.transactionUid = it.uid
                           transactionService.getSession(walletAddress, signedContent,
                               transactionUid)

--- a/app/src/main/java/com/asfoundation/wallet/billing/adyen/AdyenBillingService.kt
+++ b/app/src/main/java/com/asfoundation/wallet/billing/adyen/AdyenBillingService.kt
@@ -107,10 +107,9 @@ class AdyenBillingService(
             walletService.signContent(walletAddress)
                 .flatMap { signedContent ->
                   billing.getSkuTransaction(appPackageName, productName!!, scheduler)
-                      .doOnSuccess { purchase -> this.transactionUid = purchase.uid }
-                      .flatMap { purchase ->
-                        transactionService.getSession(walletAddress,
-                            signedContent, purchase.uid)
+                      .doOnSuccess { transaction -> this.transactionUid = transaction.uid }
+                      .flatMap {
+                        transactionService.getSession(walletAddress, signedContent, transactionUid)
                       }
                       .onErrorResumeNext {
                         adyen.token.flatMap { token ->

--- a/app/src/main/java/com/asfoundation/wallet/billing/adyen/AdyenBillingService.kt
+++ b/app/src/main/java/com/asfoundation/wallet/billing/adyen/AdyenBillingService.kt
@@ -1,12 +1,7 @@
 package com.asfoundation.wallet.billing.adyen
 
 import com.adyen.core.models.Payment
-import com.appcoins.wallet.bdsbilling.Billing
 import com.appcoins.wallet.bdsbilling.WalletService
-import com.appcoins.wallet.bdsbilling.repository.TransactionStatus
-import com.appcoins.wallet.bdsbilling.repository.TransactionType
-import com.appcoins.wallet.bdsbilling.repository.entity.Gateway
-import com.appcoins.wallet.bdsbilling.repository.entity.Transaction
 import com.asfoundation.wallet.billing.BillingService
 import com.asfoundation.wallet.billing.TransactionService
 import com.asfoundation.wallet.billing.authorization.AdyenAuthorization
@@ -14,7 +9,6 @@ import com.asfoundation.wallet.billing.partners.AddressService
 import com.jakewharton.rxrelay2.BehaviorRelay
 import io.reactivex.Completable
 import io.reactivex.Observable
-import io.reactivex.Scheduler
 import io.reactivex.Single
 import io.reactivex.functions.BiFunction
 import java.math.BigDecimal
@@ -25,9 +19,7 @@ class AdyenBillingService(
     private val transactionService: TransactionService,
     private val walletService: WalletService,
     private val adyen: Adyen,
-    private val partnerAddressService: AddressService,
-    private val billing: Billing,
-    private val scheduler: Scheduler
+    private val partnerAddressService: AddressService
 ) : BillingService {
 
   private val relay: BehaviorRelay<AdyenAuthorization> = BehaviorRelay.create()
@@ -44,7 +36,7 @@ class AdyenBillingService(
                                 orderReference: String?,
                                 appPackageName: String): Observable<AdyenAuthorization> {
     return relay.doOnSubscribe {
-      startOrResumePayment(productName, developerAddress, payload, origin,
+      startPaymentIfNeeded(productName, developerAddress, payload, origin,
           priceValue, priceCurrency, type, callback, orderReference, appPackageName)
     }
         .doOnNext { this.resetProcessingFlag(it) }
@@ -100,38 +92,34 @@ class AdyenBillingService(
     }
   }
 
-  private fun startOrResumePayment(productName: String?, developerAddress: String?,
-                                   payload: String?, origin: String, priceValue: BigDecimal,
-                                   priceCurrency: String, type: String, callback: String?,
+  private fun startPaymentIfNeeded(productName: String?, developerAddress: String?,
+                                   payload: String?,
+                                   origin: String, priceValue: BigDecimal, priceCurrency: String,
+                                   type: String, callback: String?,
                                    orderReference: String?, appPackageName: String) {
     if (!processingPayment.getAndSet(true)) {
       this.adyenAuthorization = walletService.getWalletAddress()
           .flatMap { walletAddress ->
             walletService.signContent(walletAddress)
                 .flatMap { signedContent ->
-                  billing.getTransaction(appPackageName, productName, walletAddress, signedContent,
-                      TransactionType.valueOf(type),
-                      TransactionStatus.PENDING_SERVICE_AUTHORIZATION, Gateway.Name.adyen)
-                      .flatMap {
-                        if (it.status != Transaction.Status.INVALID_TRANSACTION && it.gateway?.name == Gateway.Name.adyen) {
-                          //TODO REMOVE t.gateway?.name == Gateway.Name.appcoins_credits
-                          this.transactionUid = it.uid
-                          transactionService.getSession(walletAddress, signedContent,
-                              transactionUid)
-                        } else {
-                          adyen.token.flatMap { token ->
-                            startPayment(productName, developerAddress, payload, origin, priceValue,
-                                priceCurrency, type, callback, orderReference, appPackageName,
-                                walletAddress, signedContent, token)
-                          }
-                        }
-                      }
-                      .onErrorResumeNext {
-                        adyen.token.flatMap { token ->
-                          startPayment(productName, developerAddress, payload, origin, priceValue,
-                              priceCurrency, type, callback, orderReference, appPackageName,
-                              walletAddress, signedContent, token)
-                        }
+                  adyen.token
+                      .flatMap { token ->
+                        Single.zip<String, String, Single<String>>(
+                            partnerAddressService.getStoreAddressForPackage(appPackageName),
+                            partnerAddressService.getOemAddressForPackage(appPackageName),
+                            BiFunction { storeAddress, oemAddress ->
+                              transactionService.createTransaction(
+                                  walletAddress, signedContent, token, merchantName, payload,
+                                  productName,
+                                  developerAddress, storeAddress, oemAddress, origin, walletAddress,
+                                  priceValue, priceCurrency, type, callback, orderReference)
+                            })
+                            .flatMap { transactionUid -> transactionUid }
+                            .doOnSuccess { transactionUid -> this.transactionUid = transactionUid }
+                            .flatMap { transactionUid ->
+                              transactionService.getSession(walletAddress,
+                                  signedContent, transactionUid)
+                            }
                       }
                 }
           }
@@ -144,29 +132,5 @@ class AdyenBillingService(
 
   private fun newDefaultAdyenAuthorization(session: String): AdyenAuthorization {
     return AdyenAuthorization(session, AdyenAuthorization.Status.PENDING)
-  }
-
-  private fun startPayment(productName: String?, developerAddress: String?,
-                           payload: String?,
-                           origin: String, priceValue: BigDecimal, priceCurrency: String,
-                           type: String, callback: String?,
-                           orderReference: String?, appPackageName: String, walletAddress: String,
-                           signedContent: String, token: String): Single<String> {
-    return Single.zip<String, String, Single<String>>(
-        partnerAddressService.getStoreAddressForPackage(appPackageName),
-        partnerAddressService.getOemAddressForPackage(appPackageName),
-        BiFunction { storeAddress, oemAddress ->
-          transactionService.createTransaction(
-              walletAddress, signedContent, token, merchantName, payload,
-              productName,
-              developerAddress, storeAddress, oemAddress, origin, walletAddress,
-              priceValue, priceCurrency, type, callback, orderReference)
-        })
-        .flatMap { transactionUid -> transactionUid }
-        .doOnSuccess { transactionUid -> this.transactionUid = transactionUid }
-        .flatMap { transactionUid ->
-          transactionService.getSession(walletAddress,
-              signedContent, transactionUid)
-        }
   }
 }

--- a/app/src/main/java/com/asfoundation/wallet/di/ToolsModule.java
+++ b/app/src/main/java/com/asfoundation/wallet/di/ToolsModule.java
@@ -742,9 +742,9 @@ import static com.asfoundation.wallet.service.AppsApi.API_BASE_URL;
 
   @Singleton @Provides BillingFactory provideCreditCardBillingFactory(
       TransactionService transactionService, WalletService walletService, Adyen adyen,
-      AddressService addressService, Billing billing) {
+      AddressService addressService) {
     return merchantName -> new AdyenBillingService(merchantName, transactionService, walletService,
-        adyen, addressService, billing, Schedulers.io());
+        adyen, addressService);
   }
 
   @Singleton @Provides BdsPendingTransactionService provideBdsPendingTransactionService(

--- a/app/src/main/java/com/asfoundation/wallet/di/ToolsModule.java
+++ b/app/src/main/java/com/asfoundation/wallet/di/ToolsModule.java
@@ -742,9 +742,9 @@ import static com.asfoundation.wallet.service.AppsApi.API_BASE_URL;
 
   @Singleton @Provides BillingFactory provideCreditCardBillingFactory(
       TransactionService transactionService, WalletService walletService, Adyen adyen,
-      AddressService addressService) {
+      AddressService addressService, Billing billing) {
     return merchantName -> new AdyenBillingService(merchantName, transactionService, walletService,
-        adyen, addressService);
+        adyen, addressService, billing, Schedulers.io());
   }
 
   @Singleton @Provides BdsPendingTransactionService provideBdsPendingTransactionService(

--- a/app/src/main/java/com/asfoundation/wallet/di/ToolsModule.java
+++ b/app/src/main/java/com/asfoundation/wallet/di/ToolsModule.java
@@ -421,8 +421,8 @@ import static com.asfoundation.wallet.service.AppsApi.API_BASE_URL;
       BdsTransactionService bdsTransactionService, BillingMessagesMapper billingMessagesMapper) {
     return new AsfInAppPurchaseInteractor(inAppPurchaseService, defaultWalletInteract,
         gasSettingsInteract, new BigDecimal(BuildConfig.PAYMENT_GAS_LIMIT), parser,
-        billingMessagesMapper, billing, new ExternalBillingSerializer(), currencyConversionService,
-        bdsTransactionService, Schedulers.io(), transactionIdHelper);
+        billingMessagesMapper, billing, currencyConversionService, bdsTransactionService,
+        Schedulers.io());
   }
 
   @Singleton @Provides @Named("ASF_IN_APP_INTERACTOR")
@@ -433,8 +433,8 @@ import static com.asfoundation.wallet.service.AppsApi.API_BASE_URL;
       BdsTransactionService bdsTransactionService, BillingMessagesMapper billingMessagesMapper) {
     return new AsfInAppPurchaseInteractor(inAppPurchaseService, defaultWalletInteract,
         gasSettingsInteract, new BigDecimal(BuildConfig.PAYMENT_GAS_LIMIT), parser,
-        billingMessagesMapper, billing, new ExternalBillingSerializer(), currencyConversionService,
-        bdsTransactionService, Schedulers.io(), transactionIdHelper);
+        billingMessagesMapper, billing, currencyConversionService, bdsTransactionService,
+        Schedulers.io());
   }
 
   @Singleton @Provides InAppPurchaseInteractor provideDualInAppPurchaseInteractor(

--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/AppcoinsRewardsBuyPresenter.java
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/AppcoinsRewardsBuyPresenter.java
@@ -83,9 +83,7 @@ public class AppcoinsRewardsBuyPresenter {
       BigDecimal amount) {
     switch (transaction.getStatus()) {
       case PROCESSING:
-        return Completable.fromAction(() -> {
-          view.showLoading();
-        });
+        return Completable.fromAction(view::showLoading);
       case COMPLETED:
         if (isBds && transactionBuilder.getType()
             .equalsIgnoreCase(TransactionData.TransactionType.INAPP.name())) {

--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/AsfInAppPurchaseInteractor.java
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/AsfInAppPurchaseInteractor.java
@@ -5,7 +5,6 @@ import com.appcoins.wallet.bdsbilling.Billing;
 import com.appcoins.wallet.bdsbilling.repository.entity.Purchase;
 import com.appcoins.wallet.bdsbilling.repository.entity.Transaction;
 import com.appcoins.wallet.billing.BillingMessagesMapper;
-import com.appcoins.wallet.billing.mappers.ExternalBillingSerializer;
 import com.appcoins.wallet.billing.repository.entity.TransactionData;
 import com.asfoundation.wallet.entity.GasSettings;
 import com.asfoundation.wallet.entity.TransactionBuilder;
@@ -16,7 +15,6 @@ import com.asfoundation.wallet.repository.CurrencyConversionService;
 import com.asfoundation.wallet.repository.InAppPurchaseService;
 import com.asfoundation.wallet.repository.PaymentTransaction;
 import com.asfoundation.wallet.repository.TransactionNotFoundException;
-import com.asfoundation.wallet.util.TransactionIdHelper;
 import com.asfoundation.wallet.util.TransferParser;
 import io.reactivex.Completable;
 import io.reactivex.Observable;
@@ -29,8 +27,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class AsfInAppPurchaseInteractor {
-  public static final double GAS_PRICE_MULTIPLIER = 1.25;
-  private static final String TAG = InAppPurchaseInteractor.class.getSimpleName();
+  private static final double GAS_PRICE_MULTIPLIER = 1.25;
   private final InAppPurchaseService inAppPurchaseService;
   private final CurrencyConversionService currencyConversionService;
   private final FindDefaultWalletInteract defaultWalletInteract;
@@ -39,20 +36,15 @@ public class AsfInAppPurchaseInteractor {
   private final TransferParser parser;
   private final BillingMessagesMapper billingMessagesMapper;
   private final Billing billing;
-  private final ExternalBillingSerializer billingSerializer;
   private final BdsTransactionService trackTransactionService;
   private final Scheduler scheduler;
-
-  private final TransactionIdHelper transactionIdHelper;
 
   public AsfInAppPurchaseInteractor(InAppPurchaseService inAppPurchaseService,
       FindDefaultWalletInteract defaultWalletInteract, FetchGasSettingsInteract gasSettingsInteract,
       BigDecimal paymentGasLimit, TransferParser parser,
       BillingMessagesMapper billingMessagesMapper, Billing billing,
-      ExternalBillingSerializer billingSerializer,
       CurrencyConversionService currencyConversionService,
-      BdsTransactionService trackTransactionService, Scheduler scheduler,
-      TransactionIdHelper transactionIdHelper) {
+      BdsTransactionService trackTransactionService, Scheduler scheduler) {
     this.inAppPurchaseService = inAppPurchaseService;
     this.defaultWalletInteract = defaultWalletInteract;
     this.gasSettingsInteract = gasSettingsInteract;
@@ -60,45 +52,40 @@ public class AsfInAppPurchaseInteractor {
     this.parser = parser;
     this.billingMessagesMapper = billingMessagesMapper;
     this.billing = billing;
-    this.billingSerializer = billingSerializer;
     this.currencyConversionService = currencyConversionService;
     this.trackTransactionService = trackTransactionService;
     this.scheduler = scheduler;
-    this.transactionIdHelper = transactionIdHelper;
   }
 
-  public Single<TransactionBuilder> parseTransaction(String uri) {
+  Single<TransactionBuilder> parseTransaction(String uri) {
     return parser.parse(uri);
   }
 
   public Completable send(String uri, TransactionType transactionType, String packageName,
-      String productName, BigDecimal channelBudget, String developerPayload) {
-    switch (transactionType) {
-      case NORMAL:
-        return buildPaymentTransaction(uri, packageName, productName,
-            developerPayload).flatMapCompletable(
-            paymentTransaction -> inAppPurchaseService.send(paymentTransaction.getUri(),
-                paymentTransaction));
+      String productName, String developerPayload) {
+    if (transactionType == TransactionType.NORMAL) {
+      return buildPaymentTransaction(uri, packageName, productName,
+          developerPayload).flatMapCompletable(
+          paymentTransaction -> inAppPurchaseService.send(paymentTransaction.getUri(),
+              paymentTransaction));
     }
     return Completable.error(new UnsupportedOperationException(
         "Transaction type " + transactionType + " not supported"));
   }
 
-  public Completable resume(String uri, TransactionType transactionType, String packageName,
+  Completable resume(String uri, TransactionType transactionType, String packageName,
       String productName, String approveKey, String developerPayload) {
-    switch (transactionType) {
-      case NORMAL:
-        return buildPaymentTransaction(uri, packageName, productName,
-            developerPayload).flatMapCompletable(
-            paymentTransaction -> billing.getSkuTransaction(packageName,
-                paymentTransaction.getTransactionBuilder()
-                    .getSkuId(), scheduler)
-                .flatMapCompletable(
-                    transaction -> resumePayment(approveKey, paymentTransaction, transaction)));
-      default:
-        return Completable.error(new UnsupportedOperationException(
-            "Transaction type " + transactionType + " not supported"));
+    if (transactionType == TransactionType.NORMAL) {
+      return buildPaymentTransaction(uri, packageName, productName,
+          developerPayload).flatMapCompletable(
+          paymentTransaction -> billing.getSkuTransaction(packageName,
+              paymentTransaction.getTransactionBuilder()
+                  .getSkuId(), scheduler)
+              .flatMapCompletable(
+                  transaction -> resumePayment(approveKey, paymentTransaction, transaction)));
     }
+    return Completable.error(new UnsupportedOperationException(
+        "Transaction type " + transactionType + " not supported"));
   }
 
   private Completable resumePayment(String approveKey, PaymentTransaction paymentTransaction,
@@ -123,7 +110,7 @@ public class AsfInAppPurchaseInteractor {
     }
   }
 
-  public Observable<Payment> getTransactionState(String uri) {
+  Observable<Payment> getTransactionState(String uri) {
     return Observable.merge(inAppPurchaseService.getTransactionState(uri)
         .map(this::mapToPayment), trackTransactionService.getTransaction(uri)
         .map(this::map));
@@ -220,7 +207,7 @@ public class AsfInAppPurchaseInteractor {
             .toList());
   }
 
-  public List<BigDecimal> getTopUpChannelSuggestionValues(BigDecimal price) {
+  List<BigDecimal> getTopUpChannelSuggestionValues(BigDecimal price) {
     BigDecimal firstValue =
         price.add(new BigDecimal(5).subtract((price.remainder(new BigDecimal(5)))));
     ArrayList<BigDecimal> list = new ArrayList<>();
@@ -237,14 +224,14 @@ public class AsfInAppPurchaseInteractor {
         .map(wallet -> wallet.address);
   }
 
-  public Single<CurrentPaymentStep> getCurrentPaymentStep(String packageName,
+  Single<CurrentPaymentStep> getCurrentPaymentStep(String packageName,
       TransactionBuilder transactionBuilder) {
     return Single.zip(
         getTransaction(packageName, transactionBuilder.getSkuId(), transactionBuilder.getType()),
         isAppcoinsPaymentReady(transactionBuilder), this::map);
   }
 
-  public Single<Boolean> isAppcoinsPaymentReady(TransactionBuilder transactionBuilder) {
+  Single<Boolean> isAppcoinsPaymentReady(TransactionBuilder transactionBuilder) {
     return gasSettingsInteract.fetch(true)
         .doOnSuccess(gasSettings -> transactionBuilder.gasSettings(
             new GasSettings(gasSettings.gasPrice.multiply(new BigDecimal(GAS_PRICE_MULTIPLIER)),
@@ -285,12 +272,12 @@ public class AsfInAppPurchaseInteractor {
     }
   }
 
-  public Single<FiatValue> convertToFiat(double appcValue, String currency) {
+  Single<FiatValue> convertToFiat(double appcValue, String currency) {
     return currencyConversionService.getTokenValue(currency)
         .map(fiatValueConvertion -> calculateValue(fiatValueConvertion, appcValue));
   }
 
-  public Single<FiatValue> convertToLocalFiat(double appcValue) {
+  Single<FiatValue> convertToLocalFiat(double appcValue) {
     return currencyConversionService.getLocalFiatAmount(Double.toString(appcValue));
   }
 
@@ -301,10 +288,6 @@ public class AsfInAppPurchaseInteractor {
 
   public BillingMessagesMapper getBillingMessagesMapper() {
     return billingMessagesMapper;
-  }
-
-  public ExternalBillingSerializer getBillingSerializer() {
-    return billingSerializer;
   }
 
   public Single<Transaction> getTransaction(String packageName, String productName, String type) {
@@ -318,7 +301,7 @@ public class AsfInAppPurchaseInteractor {
     });
   }
 
-  public Single<Purchase> getCompletedPurchase(String packageName, String productName) {
+  Single<Purchase> getCompletedPurchase(String packageName, String productName) {
     return billing.getSkuTransaction(packageName, productName, Schedulers.io())
         .map(Transaction::getStatus)
         .flatMap(transactionStatus -> {

--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/BdsInAppPurchaseInteractor.java
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/BdsInAppPurchaseInteractor.java
@@ -32,9 +32,9 @@ public class BdsInAppPurchaseInteractor {
   }
 
   public Completable send(String uri, AsfInAppPurchaseInteractor.TransactionType transactionType,
-      String packageName, String productName, BigDecimal channelBudget, String developerPayload) {
+      String packageName, String productName, String developerPayload) {
     return inAppPurchaseInteractor.send(uri, transactionType, packageName, productName,
-        channelBudget, developerPayload);
+        developerPayload);
   }
 
   public Completable resume(String uri, AsfInAppPurchaseInteractor.TransactionType transactionType,

--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/InAppPurchaseInteractor.java
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/InAppPurchaseInteractor.java
@@ -65,10 +65,10 @@ public class InAppPurchaseInteractor {
       boolean isBds) {
     if (isBds) {
       return bdsInAppPurchaseInteractor.send(uri, transactionType, packageName, productName,
-          channelBudget, developerPayload);
+          developerPayload);
     } else {
       return asfInAppPurchaseInteractor.send(uri, transactionType, packageName, productName,
-          channelBudget, developerPayload);
+          developerPayload);
     }
   }
 

--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/PaymentMethodsPresenter.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/PaymentMethodsPresenter.kt
@@ -37,7 +37,7 @@ class PaymentMethodsPresenter(
     private val billing: Billing,
     private val analytics: BillingAnalytics,
     private val isBds: Boolean,
-    private val developerPayload: String,
+    private val developerPayload: String?,
     private val uri: String,
     private val gamification: GamificationInteractor,
     private val transaction: TransactionBuilder,

--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/RewardsManager.java
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/RewardsManager.java
@@ -29,15 +29,14 @@ public class RewardsManager {
   public Completable pay(String sku, BigDecimal amount, String developerAddress, String packageName,
       String origin, String type, String payload, String callbackUrl, String orderReference) {
     return Single.zip(partnerAddressService.getStoreAddressForPackage(packageName),
-        partnerAddressService.getOemAddressForPackage(packageName),
-        (storeAddress, oemAddress) -> new Pair<>(storeAddress, oemAddress))
+        partnerAddressService.getOemAddressForPackage(packageName), Pair::new)
         .flatMapCompletable(
             partnersAddresses -> appcoinsRewards.pay(amount, origin, sku, type, developerAddress,
                 partnersAddresses.first, partnersAddresses.second, packageName, payload,
                 callbackUrl, orderReference));
   }
 
-  public Single<Purchase> getPaymentCompleted(String packageName, String sku) {
+  Single<Purchase> getPaymentCompleted(String packageName, String sku) {
     return billing.getSkuPurchase(packageName, sku, Schedulers.io());
   }
 
@@ -45,8 +44,7 @@ public class RewardsManager {
     return appcoinsRewards.getPayment(packageName, sku, amount.toString());
   }
 
-  public Observable<RewardPayment> getPaymentStatus(String packageName, String sku,
-      BigDecimal amount) {
+  Observable<RewardPayment> getPaymentStatus(String packageName, String sku, BigDecimal amount) {
     return appcoinsRewards.getPayment(packageName, sku, amount.toString())
         .flatMap(this::map);
   }

--- a/app/src/test/java/com/asfoundation/wallet/ui/iab/InAppPurchaseInteractorTest.java
+++ b/app/src/test/java/com/asfoundation/wallet/ui/iab/InAppPurchaseInteractorTest.java
@@ -43,7 +43,6 @@ import com.asfoundation.wallet.service.TokenRateService;
 import com.asfoundation.wallet.ui.iab.database.AppCoinsOperationEntity;
 import com.asfoundation.wallet.util.EIPTransactionParser;
 import com.asfoundation.wallet.util.OneStepTransactionParser;
-import com.asfoundation.wallet.util.TransactionIdHelper;
 import com.asfoundation.wallet.util.TransferParser;
 import io.reactivex.Completable;
 import io.reactivex.Observable;
@@ -117,7 +116,6 @@ public class InAppPurchaseInteractorTest {
   private DataMapper dataMapper;
   private EIPTransactionParser eipTransactionParser;
   private OneStepTransactionParser oneStepTransactionParser;
-  private TransactionIdHelper transactionIdHelper = new TransactionIdHelper();
 
   @Before public void before()
       throws AppInfoProvider.UnknownApplicationException, ImageSaver.SaveException {
@@ -220,12 +218,11 @@ public class InAppPurchaseInteractorTest {
             gasSettingsInteract, BigDecimal.ONE,
             new TransferParser(eipTransactionParser, oneStepTransactionParser),
             new BillingMessagesMapper(new ExternalBillingSerializer()), billing,
-            new ExternalBillingSerializer(),
             new CurrencyConversionService(Mockito.mock(TokenRateService.class),
                 Mockito.mock(LocalCurrencyConversionService.class)),
             new BdsTransactionService(scheduler,
                 new MemoryCache<>(BehaviorSubject.create(), new ConcurrentHashMap<>()),
-                new CompositeDisposable(), transactionService), scheduler, transactionIdHelper);
+                new CompositeDisposable(), transactionService), scheduler);
 
     BillingPaymentProofSubmission billingPaymentProofSubmission =
         Mockito.mock(BillingPaymentProofSubmission.class);

--- a/app/src/test/java/com/asfoundation/wallet/ui/iab/InAppPurchaseInteractorTest.java
+++ b/app/src/test/java/com/asfoundation/wallet/ui/iab/InAppPurchaseInteractorTest.java
@@ -247,7 +247,7 @@ public class InAppPurchaseInteractorTest {
         .subscribe(testObserver);
     scheduler.triggerActions();
     inAppPurchaseInteractor.send(uri, AsfInAppPurchaseInteractor.TransactionType.NORMAL,
-        PACKAGE_NAME, PRODUCT_NAME, BigDecimal.ONE, DEVELOPER_PAYLOAD)
+        PACKAGE_NAME, PRODUCT_NAME, DEVELOPER_PAYLOAD)
         .subscribe();
     scheduler.triggerActions();
     balance.onNext(GetDefaultWalletBalance.BalanceState.OK);
@@ -307,7 +307,7 @@ public class InAppPurchaseInteractorTest {
         .subscribe(testObserver);
     scheduler.triggerActions();
     inAppPurchaseInteractor.send(uri, AsfInAppPurchaseInteractor.TransactionType.NORMAL,
-        PACKAGE_NAME, PRODUCT_NAME, BigDecimal.ONE, DEVELOPER_PAYLOAD)
+        PACKAGE_NAME, PRODUCT_NAME, DEVELOPER_PAYLOAD)
         .subscribe();
     scheduler.triggerActions();
     balance.onNext(GetDefaultWalletBalance.BalanceState.NO_ETHER);
@@ -350,7 +350,7 @@ public class InAppPurchaseInteractorTest {
         .subscribe(testObserver);
     scheduler.triggerActions();
     inAppPurchaseInteractor.send(uri, AsfInAppPurchaseInteractor.TransactionType.NORMAL,
-        PACKAGE_NAME, PRODUCT_NAME, BigDecimal.ONE, DEVELOPER_PAYLOAD)
+        PACKAGE_NAME, PRODUCT_NAME, DEVELOPER_PAYLOAD)
         .subscribe();
     scheduler.triggerActions();
     balance.onNext(GetDefaultWalletBalance.BalanceState.NO_ETHER_NO_TOKEN);

--- a/bdsbilling/src/main/java/com/appcoins/wallet/bdsbilling/BdsBilling.kt
+++ b/bdsbilling/src/main/java/com/appcoins/wallet/bdsbilling/BdsBilling.kt
@@ -1,6 +1,9 @@
 package com.appcoins.wallet.bdsbilling
 
 import com.appcoins.wallet.bdsbilling.repository.BillingSupportedType
+import com.appcoins.wallet.bdsbilling.repository.TransactionStatus
+import com.appcoins.wallet.bdsbilling.repository.TransactionType
+import com.appcoins.wallet.bdsbilling.repository.entity.Gateway
 import com.appcoins.wallet.bdsbilling.repository.entity.PaymentMethodEntity
 import com.appcoins.wallet.bdsbilling.repository.entity.Purchase
 import com.appcoins.wallet.bdsbilling.repository.entity.Transaction
@@ -53,6 +56,14 @@ class BdsBilling(private val repository: BillingRepository,
                 repository.getSkuTransaction(merchantName, sku, address, signedContent)
               }
         }
+  }
+
+  override fun getTransaction(packageName: String?, skuId: String?, walletAddress: String,
+                              signedContent: String, transactionType: TransactionType?,
+                              status: TransactionStatus?,
+                              gateway: Gateway.Name?): Single<Transaction> {
+    return repository.getTransaction(packageName, skuId, walletAddress, signedContent,
+        transactionType, status, gateway)
   }
 
   override fun getSkuPurchase(merchantName: String, sku: String,

--- a/bdsbilling/src/main/java/com/appcoins/wallet/bdsbilling/Billing.kt
+++ b/bdsbilling/src/main/java/com/appcoins/wallet/bdsbilling/Billing.kt
@@ -1,6 +1,9 @@
 package com.appcoins.wallet.bdsbilling
 
 import com.appcoins.wallet.bdsbilling.repository.BillingSupportedType
+import com.appcoins.wallet.bdsbilling.repository.TransactionStatus
+import com.appcoins.wallet.bdsbilling.repository.TransactionType
+import com.appcoins.wallet.bdsbilling.repository.entity.Gateway
 import com.appcoins.wallet.bdsbilling.repository.entity.PaymentMethodEntity
 import com.appcoins.wallet.bdsbilling.repository.entity.Purchase
 import com.appcoins.wallet.bdsbilling.repository.entity.Transaction
@@ -26,7 +29,7 @@ interface Billing {
   fun consumePurchases(merchantName: String, purchaseToken: String,
                        scheduler: Scheduler): Single<Boolean>
 
-  fun getPaymentMethods(value:String, currency:String): Single<List<PaymentMethodEntity>>
+  fun getPaymentMethods(value: String, currency: String): Single<List<PaymentMethodEntity>>
 
   enum class BillingSupportType {
     SUPPORTED, MERCHANT_NOT_FOUND, UNKNOWN_ERROR, NO_INTERNET_CONNECTION, API_ERROR
@@ -34,6 +37,10 @@ interface Billing {
 
   fun getSkuTransaction(merchantName: String, sku: String,
                         scheduler: Scheduler): Single<Transaction>
+
+  fun getTransaction(packageName: String?, skuId: String?, walletAddress: String,
+                     signedContent: String, transactionType: TransactionType?,
+                     status: TransactionStatus?, gateway: Gateway.Name?): Single<Transaction>
 
   fun getWallet(packageName: String): Single<String>
 }

--- a/bdsbilling/src/main/java/com/appcoins/wallet/bdsbilling/BillingRepository.kt
+++ b/bdsbilling/src/main/java/com/appcoins/wallet/bdsbilling/BillingRepository.kt
@@ -1,6 +1,9 @@
 package com.appcoins.wallet.bdsbilling
 
 import com.appcoins.wallet.bdsbilling.repository.BillingSupportedType
+import com.appcoins.wallet.bdsbilling.repository.TransactionStatus
+import com.appcoins.wallet.bdsbilling.repository.TransactionType
+import com.appcoins.wallet.bdsbilling.repository.entity.Gateway
 import com.appcoins.wallet.bdsbilling.repository.entity.PaymentMethodEntity
 import com.appcoins.wallet.bdsbilling.repository.entity.Purchase
 import com.appcoins.wallet.bdsbilling.repository.entity.Transaction
@@ -20,6 +23,10 @@ interface BillingRepository {
 
   fun getSkuTransaction(packageName: String, skuId: String, walletAddress: String,
                         walletSignature: String): Single<Transaction>
+
+  fun getTransaction(packageName: String?, skuId: String?, walletAddress: String,
+                     walletSignature: String, transactionType: TransactionType?,
+                     status: TransactionStatus?, gateway: Gateway.Name?): Single<Transaction>
 
   fun getPurchases(packageName: String, walletAddress: String, walletSignature: String,
                    type: BillingSupportedType): Single<List<Purchase>>

--- a/bdsbilling/src/main/java/com/appcoins/wallet/bdsbilling/repository/BdsRepository.kt
+++ b/bdsbilling/src/main/java/com/appcoins/wallet/bdsbilling/repository/BdsRepository.kt
@@ -1,6 +1,7 @@
 package com.appcoins.wallet.bdsbilling.repository
 
 import com.appcoins.wallet.bdsbilling.BillingRepository
+import com.appcoins.wallet.bdsbilling.repository.entity.Gateway
 import com.appcoins.wallet.bdsbilling.repository.entity.PaymentMethodEntity
 import com.appcoins.wallet.bdsbilling.repository.entity.Purchase
 import com.appcoins.wallet.bdsbilling.repository.entity.Transaction
@@ -59,7 +60,21 @@ class BdsRepository(private val remoteRepository: RemoteRepository) : BillingRep
                                  walletSignature: String): Single<Transaction> {
     return remoteRepository.getSkuTransaction(packageName, skuId, walletAddress, walletSignature)
         .flatMap {
-          if (!it.items.isEmpty()) {
+          if (it.items.isNotEmpty()) {
+            return@flatMap Single.just(it.items[0])
+          }
+          return@flatMap Single.just(Transaction.notFound())
+        }
+  }
+
+  override fun getTransaction(packageName: String?, skuId: String?, walletAddress: String,
+                              walletSignature: String, transactionType: TransactionType?,
+                              status: TransactionStatus?,
+                              gateway: Gateway.Name?): Single<Transaction> {
+    return remoteRepository.getTransaction(packageName, skuId, walletAddress, walletSignature,
+        transactionType, status, gateway)
+        .flatMap {
+          if (it.items.isNotEmpty()) {
             return@flatMap Single.just(it.items[0])
           }
           return@flatMap Single.just(Transaction.notFound())

--- a/bdsbilling/src/main/java/com/appcoins/wallet/bdsbilling/repository/RemoteRepository.kt
+++ b/bdsbilling/src/main/java/com/appcoins/wallet/bdsbilling/repository/RemoteRepository.kt
@@ -37,9 +37,19 @@ class RemoteRepository(private val api: BdsApi, private val responseMapper: BdsA
                                  skuId: String,
                                  walletAddress: String,
                                  walletSignature: String): Single<TransactionsResponse> {
-    return api.getSkuTransaction(walletAddress, walletSignature, 0, TransactionType.INAPP, 1,
-        "latest", false, skuId, packageName)
+    return api.getTransaction(walletAddress, walletSignature, 0, TransactionType.INAPP, 1,
+        "latest", false, skuId, packageName, null, null)
+  }
 
+  internal fun getTransaction(packageName: String?,
+                              skuId: String?,
+                              walletAddress: String,
+                              walletSignature: String,
+                              transactionType: TransactionType?,
+                              status: TransactionStatus?,
+                              gateway: Gateway.Name?): Single<TransactionsResponse> {
+    return api.getTransaction(walletAddress, walletSignature, 0, transactionType, 1,
+        "latest", false, skuId, packageName, status, gateway)
   }
 
   internal fun getPurchases(packageName: String,
@@ -155,16 +165,18 @@ class RemoteRepository(private val api: BdsApi, private val responseMapper: BdsA
                        @Query("wallet.signature") walletSignature: String): Single<Purchase>
 
     @GET("broker/8.20180518/transactions")
-    fun getSkuTransaction(
+    fun getTransaction(
         @Query("wallet.address") walletAddress: String,
         @Query("wallet.signature") walletSignature: String,
-        @Query("cursor") cursor: Long,
-        @Query("type") type: TransactionType,
+        @Query("cursor") cursor: Long?,
+        @Query("type") type: TransactionType?,
         @Query("limit") limit: Long,
-        @Query("sort.name") sort: String,
-        @Query("sort.reverse") isReverse: Boolean,
-        @Query("product") skuId: String,
-        @Query("domain") packageName: String
+        @Query("sort.name") sort: String?,
+        @Query("sort.reverse") isReverse: Boolean?,
+        @Query("product") skuId: String?,
+        @Query("domain") packageName: String?,
+        @Query("status") status: TransactionStatus?,
+        @Query("gateway") gateway: Gateway.Name?
     ): Single<TransactionsResponse>
 
     @GET("broker/8.20180518/transactions/{uId}")

--- a/bdsbilling/src/main/java/com/appcoins/wallet/bdsbilling/repository/TransactionStatus.kt
+++ b/bdsbilling/src/main/java/com/appcoins/wallet/bdsbilling/repository/TransactionStatus.kt
@@ -1,0 +1,11 @@
+package com.appcoins.wallet.bdsbilling.repository
+
+enum class TransactionStatus {
+  PENDING_SERVICE_AUTHORIZATION,
+  PENDING_USER_PAYMENT,
+  PROCESSING,
+  SETTLED,
+  COMPLETED,
+  CANCELED,
+  FAILED
+}

--- a/bdsbilling/src/main/java/com/appcoins/wallet/bdsbilling/repository/TransactionType.kt
+++ b/bdsbilling/src/main/java/com/appcoins/wallet/bdsbilling/repository/TransactionType.kt
@@ -1,5 +1,9 @@
 package com.appcoins.wallet.bdsbilling.repository
 
 enum class TransactionType {
-  INAPP
+  DONATION,
+  INAPP,
+  INAPP_UNMANAGED,
+  TOPUP,
+  TRANSFER
 }


### PR DESCRIPTION
**What does this PR do?**

   This PR introduces the recycling of adyen transactions. If a transaction is already available for the same item, reference and gateway it should be used instead of failing(some use cases) or creating a new one.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] PaymentMethodsPresenter.kt
- [ ] AdyenBillingService.kt

**How should this be manually tested?**
1 - Without a preselected method buy an item in trivial drive and check if it works
2 - With CC as preselected method buy an item in trivial drive and check if it works
3 - With CC as preselected method click oh "More payment methods" , select CC again and buy and item. It should work and use the same UID

  Flow on how to test this or QA Tickets related to this use-case: [APPC-1232](https://aptoide.atlassian.net/browse/APPC-1232)

**What are the relevant tickets?**

  Tickets related to this pull-request: [APPC-1232](https://aptoide.atlassian.net/browse/APPC-1232)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new libs, new keys, etc.)




**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass