### PR TITLE
APPC-1237 handle empty sku details

### DIFF
--- a/billing/src/main/java/com/appcoins/wallet/billing/AppcoinsBillingBinder.kt
+++ b/billing/src/main/java/com/appcoins/wallet/billing/AppcoinsBillingBinder.kt
@@ -9,6 +9,7 @@ import com.appcoins.billing.AppcoinsBilling
 import com.appcoins.wallet.bdsbilling.Billing
 import com.appcoins.wallet.bdsbilling.BillingFactory
 import com.appcoins.wallet.bdsbilling.ProxyService
+import com.appcoins.wallet.bdsbilling.exceptions.BillingException
 import com.appcoins.wallet.bdsbilling.repository.BillingSupportedType
 import com.appcoins.wallet.bdsbilling.repository.entity.Purchase
 import com.appcoins.wallet.billing.mappers.ExternalBillingSerializer
@@ -150,7 +151,12 @@ internal class AppcoinsBillingBinder(private val supportedApiVersion: Int,
                 developerPayload, true, packageName, developerAddress, skuDetails[0].sku,
                 BigDecimal(skuDetails[0].price.appcoinsAmount), skuDetails[0].title)
           } catch (exception: Exception) {
-            billingMessagesMapper.mapBuyIntentError(exception)
+            if (skuDetails.isEmpty()) {
+              billingMessagesMapper.mapBuyIntentError(
+                  Exception(BillingException(RESULT_ITEM_UNAVAILABLE)))
+            } else {
+              billingMessagesMapper.mapBuyIntentError(exception)
+            }
           }
         }).onErrorReturn { throwable ->
       billingMessagesMapper.mapBuyIntentError(


### PR DESCRIPTION
**What does this PR do?**

   When an item is not available when build the buy intent, a generic error is returned instead of returning the respective result

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] AppcoinsBillingBinder.kt

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [APPC-1237](https://aptoide.atlassian.net/browse/APPC-1237)

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass