### PR TITLE
[APPC-1154] Added success animation to appc credits flow

### DIFF
--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/AppcoinsRewardsBuyView.java
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/AppcoinsRewardsBuyView.java
@@ -25,4 +25,8 @@ interface AppcoinsRewardsBuyView {
   void errorClose();
 
   void finish(Purchase purchase, @Nullable String orderReference);
+
+  void showTransactionCompleted();
+
+  long getAnimationDuration();
 }

--- a/app/src/main/res/layout/reward_payment_layout.xml
+++ b/app/src/main/res/layout/reward_payment_layout.xml
@@ -26,4 +26,9 @@
       app:layout_constraintTop_toTopOf="parent"
       />
 
+  <include
+      layout="@layout/fragment_iab_transaction_completed"
+      android:visibility="invisible"
+      />
+
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
**What does this PR do?**

   This PR add a success animation ( without the bonus part)  to purchases with credits.

**Database changed?**

No

**Where should the reviewer start?**

- [ ] AppcoinsRewardsBuyFragment.java

**How should this be manually tested?**
   In trivial drive do a purchase with appc credits. It should display a success animation in the end. The animation shouldn't have anything related with bonus

  Flow on how to test this or QA Tickets related to this use-case: [APPC-1154](https://aptoide.atlassian.net/browse/APPC-1154)

**What are the relevant tickets?**

  Tickets related to this pull-request: [APPC-1154](https://aptoide.atlassian.net/browse/APPC-1154)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new libs, new keys, etc.)




**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass