### PR TITLE
[APPC-1242] Avoid recycle of bitmap on payment view

### DIFF
--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/PaymentMethodsFragment.java
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/PaymentMethodsFragment.java
@@ -46,10 +46,8 @@ import java.math.BigDecimal;
 import java.text.DecimalFormat;
 import java.util.ArrayList;
 import java.util.Formatter;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
 import javax.inject.Inject;
 import org.jetbrains.annotations.NotNull;
 
@@ -69,7 +67,6 @@ public class PaymentMethodsFragment extends DaggerFragment implements PaymentMet
   private static final String IS_DONATION = "is_donation";
 
   private final CompositeDisposable compositeDisposable = new CompositeDisposable();
-  private final Map<String, Bitmap> loadedBitmaps = new HashMap<>();
   PaymentMethodsPresenter presenter;
   @Inject InAppPurchaseInteractor inAppPurchaseInteractor;
   @Inject BillingAnalytics analytics;
@@ -238,11 +235,6 @@ public class PaymentMethodsFragment extends DaggerFragment implements PaymentMet
 
   @Override public void onDestroy() {
     super.onDestroy();
-
-    for (Bitmap bitmap : loadedBitmaps.values()) {
-      bitmap.recycle();
-    }
-    loadedBitmaps.clear();
   }
 
   @Override public void onDetach() {
@@ -320,6 +312,7 @@ public class PaymentMethodsFragment extends DaggerFragment implements PaymentMet
     addressFooter.setVisibility(View.GONE);
     mainView.setVisibility(View.GONE);
     itemAlreadyOwnedError = true;
+    iabView.disableBack();
     iabView.disableBack();
     View view = getView();
     if (view != null) {
@@ -488,7 +481,6 @@ public class PaymentMethodsFragment extends DaggerFragment implements PaymentMet
         Bitmap bitmap = Picasso.with(context)
             .load(paymentMethod.getIconUrl())
             .get();
-        loadedBitmaps.put(paymentMethod.getId(), bitmap);
         BitmapDrawable drawable = new BitmapDrawable(context.getResources(),
             Bitmap.createScaledBitmap(bitmap, iconSize, iconSize, true));
         return drawable.getCurrent();

--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/PaymentMethodsFragment.java
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/PaymentMethodsFragment.java
@@ -313,7 +313,6 @@ public class PaymentMethodsFragment extends DaggerFragment implements PaymentMet
     mainView.setVisibility(View.GONE);
     itemAlreadyOwnedError = true;
     iabView.disableBack();
-    iabView.disableBack();
     View view = getView();
     if (view != null) {
       view.setFocusableInTouchMode(true);


### PR DESCRIPTION
**What does this PR do?**

Follows up the previous PRs with make sure that it doesn’t happen in the future.
It seems that after pre-honeycomb we don’t need to recycle bitmaps unless we want to release memory asap which was not the case.

**Database changed?**

No

**Where should the reviewer start?**

-PaymentMethodsFragment.java

**How should this be manually tested?**

Could not reproduce, so just check if indeed there’s not a leak due to the lines erased.

**What are the relevant tickets?**

https://aptoide.atlassian.net/browse/APPC-1242

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass