### PR TITLE
[APPC-1153] TopUp success message when bonus is inactive

### DIFF
--- a/app/src/main/java/com/asfoundation/wallet/topup/TopUpSuccessFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/topup/TopUpSuccessFragment.kt
@@ -99,11 +99,12 @@ class TopUpSuccessFragment : DaggerFragment(), TopUpSuccessFragmentView {
     if (bonus.isNotBlank()) {
       top_up_success_animation.setAnimation(R.raw.top_up_bonus_success_animation)
       setAnimationText()
+      formatBonusSuccessMessage()
     } else {
       top_up_success_animation.setAnimation(R.raw.top_up_success_animation)
+      formatSuccessMessage()
     }
     top_up_success_animation.playAnimation()
-    formatBonusSuccessMessage()
   }
 
   override fun clean() {
@@ -112,10 +113,10 @@ class TopUpSuccessFragment : DaggerFragment(), TopUpSuccessFragmentView {
     top_up_success_animation.removeAllLottieOnCompositionLoadedListener()
   }
 
-
   override fun close() {
     topUpActivityView.close()
   }
+
 
   override fun getOKClicks(): Observable<Any> {
     return RxView.clicks(button)
@@ -135,16 +136,31 @@ class TopUpSuccessFragment : DaggerFragment(), TopUpSuccessFragmentView {
   }
 
   private fun formatBonusSuccessMessage() {
-    val fiatValue =
-        BigDecimal(amount).setScale(2, RoundingMode.FLOOR).toString() + " " + currency
-    val formattedInitialString = String.format(
-        resources.getString(R.string.topup_completed_1), fiatValue)
+    val formattedInitialString = getFormattedTopUpValue()
     val topUpString =
         formattedInitialString + " " + resources.getString(R.string.topup_completed_2_with_bonus)
-    val boldStyle = StyleSpan(Typeface.BOLD)
-    val sb = SpannableString(topUpString)
-    sb.setSpan(boldStyle, 0, formattedInitialString.length, Spannable.SPAN_INCLUSIVE_INCLUSIVE)
-    value.text = sb
+    setSpannableString(topUpString, formattedInitialString.length)
+
   }
 
+  private fun formatSuccessMessage() {
+    val formattedInitialString = getFormattedTopUpValue()
+    val secondStringFormat =
+        String.format(resources.getString(R.string.askafriend_notification_received_body),
+            formattedInitialString, "\n")
+    setSpannableString(secondStringFormat, formattedInitialString.length)
+  }
+
+  private fun getFormattedTopUpValue(): String {
+    val fiatValue =
+        BigDecimal(amount).setScale(2, RoundingMode.FLOOR).toString() + " " + currency
+    return String.format(resources.getString(R.string.topup_completed_1), fiatValue)
+  }
+
+  private fun setSpannableString(secondStringFormat: String, firstStringLength: Int) {
+    val boldStyle = StyleSpan(Typeface.BOLD)
+    val sb = SpannableString(secondStringFormat)
+    sb.setSpan(boldStyle, 0, firstStringLength, Spannable.SPAN_INCLUSIVE_INCLUSIVE)
+    value.text = sb
+  }
 }


### PR DESCRIPTION
**What does this PR do?**

   Adds previous string to the top success view in case there’s no active bonus

**Database changed?**

No

**How should this be manually tested?**

  Change bonusMessageValue in TopUpFragment to “” and check if the correct message shows up.
  Check if the normal message also shows up without modifications.

**What are the relevant tickets?**

  https://aptoide.atlassian.net/browse/APPC-1153

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass