### PR TITLE
[APPC-1272] Fixed 409 error overlapping item already owned error

### DIFF
--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/PaymentMethodsFragment.java
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/PaymentMethodsFragment.java
@@ -321,11 +321,13 @@ public class PaymentMethodsFragment extends DaggerFragment implements PaymentMet
   }
 
   @Override public void showError(int message) {
-    loadingView.setVisibility(View.GONE);
-    dialog.setVisibility(View.GONE);
-    mainView.setVisibility(View.GONE);
-    errorView.setVisibility(View.VISIBLE);
-    errorMessage.setText(message);
+    if (!itemAlreadyOwnedError) {
+      loadingView.setVisibility(View.GONE);
+      dialog.setVisibility(View.GONE);
+      mainView.setVisibility(View.GONE);
+      errorView.setVisibility(View.VISIBLE);
+      errorMessage.setText(message);
+    }
   }
 
   @Override public void showItemAlreadyOwnedError() {
@@ -412,8 +414,10 @@ public class PaymentMethodsFragment extends DaggerFragment implements PaymentMet
 
   @Override public void showAdyen(@NotNull FiatValue fiatValue, @NotNull PaymentType paymentType,
       String iconUrl) {
-    iabView.showAdyenPayment(fiatValue.getAmount(), fiatValue.getCurrency(), isBds, paymentType,
-        bonusMessageValue, true, iconUrl);
+    if (!itemAlreadyOwnedError) {
+      iabView.showAdyenPayment(fiatValue.getAmount(), fiatValue.getCurrency(), isBds, paymentType,
+          bonusMessageValue, true, iconUrl);
+    }
   }
 
   @Override public void showCreditCard() {

--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/PaymentMethodsPresenter.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/PaymentMethodsPresenter.kt
@@ -21,6 +21,7 @@ import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.functions.Action
 import io.reactivex.schedulers.Schedulers
+import retrofit2.HttpException
 import java.io.IOException
 import java.math.BigDecimal
 import java.util.*
@@ -271,11 +272,15 @@ class PaymentMethodsPresenter(
 
   private fun showError(t: Throwable) {
     t.printStackTrace()
-    if (isNoNetworkException(t)) {
-      view.showError(R.string.notification_no_network_poa)
-    } else {
-      view.showError(R.string.activity_iab_error_message)
+    when {
+      isNoNetworkException(t) -> view.showError(R.string.notification_no_network_poa)
+      isItemAlreadyOwnedError(t) -> view.showItemAlreadyOwnedError()
+      else -> view.showError(R.string.activity_iab_error_message)
     }
+  }
+
+  private fun isItemAlreadyOwnedError(throwable: Throwable): Boolean {
+    return throwable is HttpException && throwable.code() == 409
   }
 
   private fun isNoNetworkException(throwable: Throwable): Boolean {


### PR DESCRIPTION
**What does this PR do?**

   Fixes 409 error view overlapping item already owned error view. This was happening when CC was the pre-selected method and the user had a purchase not consumed.

**Database changed?**

    No

**Where should the reviewer start?**

PaymentMethodsFragment.kt

**How should this be manually tested?**

Use the b11 wallet to try make a purchase of the 0.99€ gems in Creative Destruction and check if it only shows the item already owned error view.

**What are the relevant tickets?**

  https://aptoide.atlassian.net/browse/APPC-1272

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass