### PR TITLE
[APPC-1320] Locked rotation after payments are initialised 

### DIFF
--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/AdyenAuthorizationFragment.java
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/AdyenAuthorizationFragment.java
@@ -504,6 +504,10 @@ public class AdyenAuthorizationFragment extends DaggerFragment implements AdyenA
     buyButton.setVisibility(valid ? View.VISIBLE : View.INVISIBLE);
   }
 
+  @Override public void lockRotation() {
+    iabView.lockRotation();
+  }
+
   private void finishSetupView() {
     int paddingTop = isPreSelected() ? 0 : 50;
     int paddingLeft = isPreSelected() ? 0 : 24;

--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/AdyenAuthorizationPresenter.java
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/AdyenAuthorizationPresenter.java
@@ -301,7 +301,10 @@ public class AdyenAuthorizationPresenter {
 
   private void handlePaymentMethodResults() {
     disposables.add(view.paymentMethodDetailsEvent()
-        .doOnNext(__ -> view.showLoading())
+        .doOnNext(__ -> {
+          view.showLoading();
+          view.lockRotation();
+        })
         .flatMapCompletable(adyen::finishPayment)
         .observeOn(viewScheduler)
         .subscribe(() -> {
@@ -333,6 +336,7 @@ public class AdyenAuthorizationPresenter {
         .filter(s -> !waitingResult)
         .flatMapSingle(redirectUrl -> transactionBuilder.doOnSuccess(transaction -> {
           view.showLoading();
+          view.lockRotation();
           navigator.navigateToUriForResult(redirectUrl);
           waitingResult = true;
           sendPaymentMethodDetailsEvent(PAYMENT_METHOD_PAYPAL);

--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/AdyenAuthorizationView.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/AdyenAuthorizationView.kt
@@ -30,4 +30,5 @@ interface AdyenAuthorizationView {
   fun showMoreMethods()
   fun onValidFieldStateChange(): Observable<Boolean>
   fun updateButton(valid: Boolean)
+  fun lockRotation()
 }

--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/AppcoinsRewardsBuyFragment.java
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/AppcoinsRewardsBuyFragment.java
@@ -175,6 +175,10 @@ public class AppcoinsRewardsBuyFragment extends DaggerFragment implements Appcoi
     return lottieTransactionComplete.getDuration();
   }
 
+  @Override public void lockRotation() {
+    iabView.lockRotation();
+  }
+
   @Override public void onAttach(Context context) {
     super.onAttach(context);
     if (!(context instanceof IabView)) {

--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/AppcoinsRewardsBuyPresenter.java
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/AppcoinsRewardsBuyPresenter.java
@@ -47,6 +47,7 @@ public class AppcoinsRewardsBuyPresenter {
   }
 
   public void present() {
+    view.lockRotation();
     handleBuyClick();
     handleOkErrorClick();
   }

--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/AppcoinsRewardsBuyView.java
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/AppcoinsRewardsBuyView.java
@@ -29,4 +29,6 @@ interface AppcoinsRewardsBuyView {
   void showTransactionCompleted();
 
   long getAnimationDuration();
+
+  void lockRotation();
 }

--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/IabActivity.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/IabActivity.kt
@@ -2,6 +2,7 @@ package com.asfoundation.wallet.ui.iab
 
 import android.app.Activity
 import android.content.Intent
+import android.content.pm.ActivityInfo
 import android.net.Uri
 import android.os.Bundle
 import com.appcoins.wallet.billing.AppcoinsBillingBinder.Companion.EXTRA_BDS_IAP
@@ -27,7 +28,6 @@ import javax.inject.Inject
  */
 
 class IabActivity : BaseActivity(), IabView, UriNavigator {
-
 
   @Inject
   lateinit var inAppPurchaseInteractor: InAppPurchaseInteractor
@@ -226,6 +226,14 @@ class IabActivity : BaseActivity(), IabView, UriNavigator {
 
   override fun uriResults(): Observable<Uri>? {
     return results
+  }
+
+  override fun lockRotation() {
+    requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_LOCKED
+  }
+
+  override fun unlockRotation() {
+    requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED
   }
 
   companion object {

--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/IabView.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/IabView.kt
@@ -35,4 +35,7 @@ interface IabView {
   fun showMergedAppcoins(fiatAmount: BigDecimal, currency: String, bonus: String,
                          productName: String?, appcEnabled: Boolean, creditsEnabled: Boolean,
                          isBds: Boolean, isDonation: Boolean)
+
+  fun lockRotation()
+  fun unlockRotation()
 }

--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/LocalPaymentFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/LocalPaymentFragment.kt
@@ -342,4 +342,8 @@ class LocalPaymentFragment : DaggerFragment(), LocalPaymentView {
         paymentId)
     iabView.finish(bundle)
   }
+
+  override fun lockRotation() {
+    iabView.lockRotation()
+  }
 }

--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/LocalPaymentPresenter.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/LocalPaymentPresenter.kt
@@ -64,16 +64,16 @@ class LocalPaymentPresenter(private val view: LocalPaymentView,
   }
 
   private fun handlePaymentRedirect() {
-    disposables.add(
-        navigator.uriResults().doOnNext {
-          view.showProcessingLoading()
-        }.flatMap {
+    disposables.add(navigator.uriResults()
+        .doOnNext { view.showProcessingLoading() }
+        .doOnNext { view.lockRotation() }
+        .flatMap {
           localPaymentInteractor.getTransaction(it)
               .subscribeOn(networkScheduler)
-        }.observeOn(viewScheduler)
-            .flatMapCompletable { handleTransactionStatus(it) }
-            .subscribe({}, { showError(it) }
-            ))
+        }
+        .observeOn(viewScheduler)
+        .flatMapCompletable { handleTransactionStatus(it) }
+        .subscribe({}, { showError(it) }))
   }
 
   private fun handleOkErrorButtonClick() {

--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/LocalPaymentView.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/LocalPaymentView.kt
@@ -15,6 +15,7 @@ interface LocalPaymentView {
   fun close()
   fun getAnimationDuration(): Long
   fun popView(bundle: Bundle)
+  fun lockRotation()
 
   enum class ViewState {
     NONE, COMPLETED, PENDING_USER_PAYMENT, ERROR, LOADING

--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/OnChainBuyFragment.java
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/OnChainBuyFragment.java
@@ -171,6 +171,7 @@ public class OnChainBuyFragment extends DaggerFragment implements OnChainBuyView
   }
 
   @Override public void showTransactionCompleted() {
+    iabView.lockRotation();
     loadingView.setVisibility(View.GONE);
     transactionErrorLayout.setVisibility(View.GONE);
     transactionCompletedLayout.setVisibility(View.VISIBLE);


### PR DESCRIPTION
**What does this PR do?**

  Follow on the bug reported in the ticket. This PR aims to lock the rotation after the transactions are initialised

**Database changed?**

 No

**Where should the reviewer start?**

IabView.kt

**How should this be manually tested?**

Do a purchase with each payment method and check if there’s no strange behaviour

**What are the relevant tickets?**

https://aptoide.atlassian.net/browse/APPC-1320

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass