### PR TITLE
[APPC-1362] Added hability to press to delete to clearsms validation codes

### DIFF
--- a/app/src/main/java/com/asfoundation/wallet/wallet_validation/DeleteKeyListener.kt
+++ b/app/src/main/java/com/asfoundation/wallet/wallet_validation/DeleteKeyListener.kt
@@ -10,8 +10,8 @@ class DeleteKeyListener(
 ) : View.OnKeyListener {
 
   override fun onKey(v: View?, keyCode: Int, event: KeyEvent?): Boolean {
-    if (keyCode == KeyEvent.KEYCODE_DEL) {
-      inputTexts[selectedPosition].text = null
+    if (event?.action == KeyEvent.ACTION_DOWN && keyCode == KeyEvent.KEYCODE_DEL) {
+      inputTexts[selectedPosition].setText("")
       if (selectedPosition > 0) {
         inputTexts[selectedPosition - 1].requestFocus()
       }

--- a/app/src/main/java/com/asfoundation/wallet/wallet_validation/DeleteKeyListener.kt
+++ b/app/src/main/java/com/asfoundation/wallet/wallet_validation/DeleteKeyListener.kt
@@ -1,0 +1,23 @@
+package com.asfoundation.wallet.wallet_validation
+
+import android.view.KeyEvent
+import android.view.View
+import android.widget.EditText
+
+class DeleteKeyListener(
+    private val inputTexts: Array<EditText>,
+    private val selectedPosition: Int
+) : View.OnKeyListener {
+
+  override fun onKey(v: View?, keyCode: Int, event: KeyEvent?): Boolean {
+    if (keyCode == KeyEvent.KEYCODE_DEL) {
+      inputTexts[selectedPosition].text = null
+      if (selectedPosition > 0) {
+        inputTexts[selectedPosition - 1].requestFocus()
+      }
+      return true
+    }
+    return false
+  }
+
+}

--- a/app/src/main/java/com/asfoundation/wallet/wallet_validation/generic/CodeValidationFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/wallet_validation/generic/CodeValidationFragment.kt
@@ -14,6 +14,7 @@ import com.asf.wallet.R
 import com.asfoundation.wallet.interact.FindDefaultWalletInteract
 import com.asfoundation.wallet.interact.SmsValidationInteract
 import com.asfoundation.wallet.referrals.ReferralInteractorContract
+import com.asfoundation.wallet.wallet_validation.DeleteKeyListener
 import com.asfoundation.wallet.wallet_validation.PasteTextWatcher
 import com.asfoundation.wallet.wallet_validation.ValidationInfo
 import com.jakewharton.rxbinding2.view.RxView
@@ -151,6 +152,12 @@ class CodeValidationFragment : DaggerFragment(),
     code_4.code.addTextChangedListener(PasteTextWatcher(inputTexts, clipboard, 3))
     code_5.code.addTextChangedListener(PasteTextWatcher(inputTexts, clipboard, 4))
     code_6.code.addTextChangedListener(PasteTextWatcher(inputTexts, clipboard, 5))
+    code_1.code.setOnKeyListener(DeleteKeyListener(inputTexts, 0))
+    code_2.code.setOnKeyListener(DeleteKeyListener(inputTexts, 1))
+    code_3.code.setOnKeyListener(DeleteKeyListener(inputTexts, 2))
+    code_4.code.setOnKeyListener(DeleteKeyListener(inputTexts, 3))
+    code_5.code.setOnKeyListener(DeleteKeyListener(inputTexts, 4))
+    code_6.code.setOnKeyListener(DeleteKeyListener(inputTexts, 5))
   }
 
   override fun clearUI() {
@@ -271,14 +278,14 @@ class CodeValidationFragment : DaggerFragment(),
     validate_code_animation.playAnimation()
   }
 
-  override fun showReferralEligible(currency: String, pendingAmount: String) {
+  override fun showReferralEligible(currency: String, maxAmount: String) {
     walletValidationView?.showLastStepAnimation()
     content.visibility = View.GONE
     animation_validating_code.visibility = View.GONE
     referral_status.visibility = View.VISIBLE
     referral_status_title.setText(R.string.referral_verification_confirmation_title)
     referral_status_body.text =
-        getString(R.string.referral_verification_confirmation_body, currency + pendingAmount)
+        getString(R.string.referral_verification_confirmation_body, currency + maxAmount)
     referral_status_animation.setAnimation(R.raw.referral_invited)
     referral_status_animation.playAnimation()
   }

--- a/app/src/main/java/com/asfoundation/wallet/wallet_validation/poa/PoaCodeValidationFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/wallet_validation/poa/PoaCodeValidationFragment.kt
@@ -12,6 +12,7 @@ import android.widget.EditText
 import androidx.fragment.app.Fragment
 import com.asf.wallet.R
 import com.asfoundation.wallet.interact.SmsValidationInteract
+import com.asfoundation.wallet.wallet_validation.DeleteKeyListener
 import com.asfoundation.wallet.wallet_validation.PasteTextWatcher
 import com.asfoundation.wallet.wallet_validation.ValidationInfo
 import com.jakewharton.rxbinding2.view.RxView
@@ -135,6 +136,12 @@ class PoaCodeValidationFragment : DaggerFragment(),
     code_4.code.addTextChangedListener(PasteTextWatcher(inputTexts, clipboard, 3))
     code_5.code.addTextChangedListener(PasteTextWatcher(inputTexts, clipboard, 4))
     code_6.code.addTextChangedListener(PasteTextWatcher(inputTexts, clipboard, 5))
+    code_1.code.setOnKeyListener(DeleteKeyListener(inputTexts, 0))
+    code_2.code.setOnKeyListener(DeleteKeyListener(inputTexts, 1))
+    code_3.code.setOnKeyListener(DeleteKeyListener(inputTexts, 2))
+    code_4.code.setOnKeyListener(DeleteKeyListener(inputTexts, 3))
+    code_5.code.setOnKeyListener(DeleteKeyListener(inputTexts, 4))
+    code_6.code.setOnKeyListener(DeleteKeyListener(inputTexts, 5))
   }
 
   override fun clearUI() {

--- a/app/src/main/res/layout/fragment_sms_code.xml
+++ b/app/src/main/res/layout/fragment_sms_code.xml
@@ -26,6 +26,14 @@
       app:layout_constraintTop_toTopOf="parent"
       />
 
+  <androidx.constraintlayout.widget.Guideline
+      android:id="@+id/guideline"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:orientation="vertical"
+      app:layout_constraintGuide_percent="0.15"
+      />
+
   <include
       android:id="@+id/text_layout"
       layout="@layout/sms_text_input_layout"
@@ -34,7 +42,17 @@
       android:layout_marginStart="70dp"
       android:layout_marginTop="30dp"
       android:layout_marginEnd="70dp"
+      app:layout_constraintEnd_toEndOf="@id/guideline2"
+      app:layout_constraintStart_toStartOf="@id/guideline"
       app:layout_constraintTop_toBottomOf="@id/title"
+      />
+
+  <androidx.constraintlayout.widget.Guideline
+      android:id="@+id/guideline2"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:orientation="vertical"
+      app:layout_constraintGuide_percent="0.85"
       />
 
   <TextView

--- a/app/src/main/res/layout/single_sms_input_layout.xml
+++ b/app/src/main/res/layout/single_sms_input_layout.xml
@@ -17,6 +17,7 @@
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
       android:layout_weight="1"
+      android:gravity="center_horizontal"
       android:imeOptions="flagNoExtractUi|flagNoFullscreen"
       android:inputType="number"
       android:maxLength="6"
@@ -27,5 +28,6 @@
       android:textSize="16sp"
       app:layout_constraintEnd_toEndOf="parent"
       app:layout_constraintStart_toStartOf="parent"
+      tools:text="5"
       />
 </com.google.android.material.textfield.TextInputLayout>


### PR DESCRIPTION

**What does this PR do?**

   This PR implements a new key event listener so the user can press delete to delete sms validation codes.

**Database changed?**

 No

**Where should the reviewer start?**

- [ ] CodeValidationFragment.kt
- [ ] PoaCodeValidationFragment.kt

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [APPC-1362](https://aptoide.atlassian.net/browse/APPC-1362)

**What are the relevant tickets?**

  Tickets related to this pull-request: [APPC-1362](https://aptoide.atlassian.net/browse/APPC-1362)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new libs, new keys, etc.)




**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass