### PR TITLE
[APPC-1377] Removal usage of received amount as trigger to referral update

### DIFF
--- a/app/src/main/java/com/asfoundation/wallet/promotions/PromotionsInteractor.kt
+++ b/app/src/main/java/com/asfoundation/wallet/promotions/PromotionsInteractor.kt
@@ -14,19 +14,17 @@ class PromotionsInteractor(private val referralInteractor: ReferralInteractorCon
                            private val findWalletInteract: FindDefaultWalletInteract) :
     PromotionsInteractorContract {
 
-  override fun hasReferralUpdate(friendsInvited: Int, receivedValue: BigDecimal,
-                                 isVerified: Boolean, screen: ReferralsScreen): Single<Boolean> {
+  override fun hasReferralUpdate(friendsInvited: Int, isVerified: Boolean,
+                                 screen: ReferralsScreen): Single<Boolean> {
     return findWalletInteract.find()
         .flatMap {
-          referralInteractor.hasReferralUpdate(it.address, friendsInvited, receivedValue,
-              isVerified, screen)
+          referralInteractor.hasReferralUpdate(it.address, friendsInvited, isVerified, screen)
         }
   }
 
-  override fun saveReferralInformation(friendsInvited: Int, receivedValue: BigDecimal,
-                                       isVerified: Boolean, screen: ReferralsScreen): Completable {
-    return referralInteractor.saveReferralInformation(friendsInvited, receivedValue.toString(),
-        isVerified, screen)
+  override fun saveReferralInformation(friendsInvited: Int, isVerified: Boolean,
+                                       screen: ReferralsScreen): Completable {
+    return referralInteractor.saveReferralInformation(friendsInvited, isVerified, screen)
 
   }
 

--- a/app/src/main/java/com/asfoundation/wallet/promotions/PromotionsInteractorContract.kt
+++ b/app/src/main/java/com/asfoundation/wallet/promotions/PromotionsInteractorContract.kt
@@ -3,15 +3,14 @@ package com.asfoundation.wallet.promotions
 import com.asfoundation.wallet.referrals.ReferralsScreen
 import io.reactivex.Completable
 import io.reactivex.Single
-import java.math.BigDecimal
 
 interface PromotionsInteractorContract {
 
   fun retrievePromotions(): Single<PromotionsViewModel>
 
-  fun saveReferralInformation(friendsInvited: Int, receivedValue: BigDecimal, isVerified: Boolean,
+  fun saveReferralInformation(friendsInvited: Int, isVerified: Boolean,
                               screen: ReferralsScreen): Completable
 
-  fun hasReferralUpdate(friendsInvited: Int, receivedValue: BigDecimal, isVerified: Boolean,
+  fun hasReferralUpdate(friendsInvited: Int, isVerified: Boolean,
                         screen: ReferralsScreen): Single<Boolean>
 }

--- a/app/src/main/java/com/asfoundation/wallet/promotions/PromotionsPresenter.kt
+++ b/app/src/main/java/com/asfoundation/wallet/promotions/PromotionsPresenter.kt
@@ -133,15 +133,13 @@ class PromotionsPresenter(private val view: PromotionsView,
 
   private fun checkForUpdates(promotionsViewModel: PromotionsViewModel) {
     disposables.add(promotionsInteractor.hasReferralUpdate(promotionsViewModel.numberOfInvitations,
-        promotionsViewModel.receivedValue, promotionsViewModel.isValidated,
-        ReferralsScreen.INVITE_FRIENDS)
+        promotionsViewModel.isValidated, ReferralsScreen.INVITE_FRIENDS)
         .subscribeOn(networkScheduler)
         .observeOn(viewScheduler)
         .doOnSuccess { view.showReferralUpdate(it) }
         .flatMapCompletable {
           promotionsInteractor.saveReferralInformation(promotionsViewModel.numberOfInvitations,
-              promotionsViewModel.receivedValue, promotionsViewModel.isValidated,
-              ReferralsScreen.PROMOTIONS)
+              promotionsViewModel.isValidated, ReferralsScreen.PROMOTIONS)
         }
         .subscribeOn(networkScheduler)
         .subscribe({}, { handleError(it) }))

--- a/app/src/main/java/com/asfoundation/wallet/referrals/InviteFriendsActivityPresenter.kt
+++ b/app/src/main/java/com/asfoundation/wallet/referrals/InviteFriendsActivityPresenter.kt
@@ -26,8 +26,8 @@ class InviteFriendsActivityPresenter(private val activity: InviteFriendsActivity
         .observeOn(viewScheduler)
         .doOnSuccess { handleValidationResult(it) }
         .flatMapCompletable {
-          referralInteractor.saveReferralInformation(it.completed, it.receivedAmount.toString(),
-              it.link != null, ReferralsScreen.INVITE_FRIENDS)
+          referralInteractor.saveReferralInformation(it.completed, it.link != null,
+              ReferralsScreen.INVITE_FRIENDS)
         }
         .subscribe({}, { handleError(it) })
     )

--- a/app/src/main/java/com/asfoundation/wallet/referrals/ReferralInteractor.kt
+++ b/app/src/main/java/com/asfoundation/wallet/referrals/ReferralInteractor.kt
@@ -16,11 +16,11 @@ class ReferralInteractor(
     private val promotionsRepository: PromotionsRepository) :
     ReferralInteractorContract {
 
-  override fun hasReferralUpdate(address: String, friendsInvited: Int, receivedValue: BigDecimal,
-                                 isVerified: Boolean, screen: ReferralsScreen): Single<Boolean> {
+  override fun hasReferralUpdate(address: String, friendsInvited: Int, isVerified: Boolean,
+                                 screen: ReferralsScreen): Single<Boolean> {
     return getReferralInformation(address, screen)
         .map {
-          hasDifferentInformation(receivedValue.toString() + friendsInvited + isVerified, it)
+          hasDifferentInformation(friendsInvited.toString() + isVerified, it)
         }
   }
 
@@ -29,7 +29,7 @@ class ReferralInteractor(
         .flatMap { wallet ->
           promotionsRepository.getReferralUserStatus(wallet.address)
               .flatMap {
-                hasReferralUpdate(wallet.address, it.completed, it.receivedAmount,
+                hasReferralUpdate(wallet.address, it.completed,
                     it.link != null, screen)
               }
         }
@@ -40,11 +40,11 @@ class ReferralInteractor(
         .flatMap { promotionsRepository.getReferralUserStatus(it.address) }
   }
 
-  override fun saveReferralInformation(numberOfFriends: Int, totalEarned: String,
-                                       isVerified: Boolean, screen: ReferralsScreen): Completable {
+  override fun saveReferralInformation(numberOfFriends: Int, isVerified: Boolean,
+                                       screen: ReferralsScreen): Completable {
     return defaultWallet.find()
         .flatMapCompletable {
-          saveReferralInformation(it.address, totalEarned, numberOfFriends, isVerified, screen)
+          saveReferralInformation(it.address, numberOfFriends, isVerified, screen)
         }
   }
 
@@ -52,10 +52,10 @@ class ReferralInteractor(
     return preferences.getReferralInformation(address, screen.toString())
   }
 
-  private fun saveReferralInformation(address: String, totalEarned: String, numberOfFriends: Int,
+  private fun saveReferralInformation(address: String, numberOfFriends: Int,
                                       isVerified: Boolean,
                                       screen: ReferralsScreen): Completable {
-    return preferences.saveReferralInformation(address, totalEarned, numberOfFriends, isVerified,
+    return preferences.saveReferralInformation(address, numberOfFriends, isVerified,
         screen.toString())
   }
 

--- a/app/src/main/java/com/asfoundation/wallet/referrals/ReferralInteractorContract.kt
+++ b/app/src/main/java/com/asfoundation/wallet/referrals/ReferralInteractorContract.kt
@@ -4,18 +4,17 @@ import com.appcoins.wallet.gamification.repository.entity.ReferralResponse
 import io.reactivex.Completable
 import io.reactivex.Maybe
 import io.reactivex.Single
-import java.math.BigDecimal
 
 interface ReferralInteractorContract {
 
-  fun hasReferralUpdate(address: String, friendsInvited: Int, receivedValue: BigDecimal,
-                        isVerified: Boolean, screen: ReferralsScreen): Single<Boolean>
+  fun hasReferralUpdate(address: String, friendsInvited: Int, isVerified: Boolean,
+                        screen: ReferralsScreen): Single<Boolean>
 
   fun hasReferralUpdate(screen: ReferralsScreen): Single<Boolean>
 
   fun retrieveReferral(): Single<ReferralResponse>
 
-  fun saveReferralInformation(numberOfFriends: Int, totalEarned: String, isVerified: Boolean,
+  fun saveReferralInformation(numberOfFriends: Int, isVerified: Boolean,
                               screen: ReferralsScreen): Completable
 
   fun getReferralNotifications(): Maybe<List<ReferralNotification>>

--- a/app/src/main/java/com/asfoundation/wallet/referrals/ReferralLocalData.kt
+++ b/app/src/main/java/com/asfoundation/wallet/referrals/ReferralLocalData.kt
@@ -4,7 +4,7 @@ import io.reactivex.Completable
 import io.reactivex.Single
 
 interface ReferralLocalData {
-  fun saveReferralInformation(address: String, totalEarned: String, invitedFriends: Int,
+  fun saveReferralInformation(address: String, invitedFriends: Int,
                               isVerified: Boolean, screen: String): Completable
 
   fun getReferralInformation(address: String, screen: String): Single<String>

--- a/app/src/main/java/com/asfoundation/wallet/referrals/SharedPreferencesReferralLocalData.kt
+++ b/app/src/main/java/com/asfoundation/wallet/referrals/SharedPreferencesReferralLocalData.kt
@@ -7,11 +7,11 @@ import io.reactivex.Single
 class SharedPreferencesReferralLocalData(private val preferences: SharedPreferences) :
     ReferralLocalData {
 
-  override fun saveReferralInformation(address: String, totalEarned: String, invitedFriends: Int,
+  override fun saveReferralInformation(address: String, invitedFriends: Int,
                                        isVerified: Boolean, screen: String): Completable {
     return Completable.fromCallable {
       preferences.edit()
-          .putString(getKey(address, screen), totalEarned + invitedFriends + isVerified)
+          .putString(getKey(address, screen), invitedFriends.toString() + isVerified)
           .apply()
     }
   }


### PR DESCRIPTION
**What does this PR do?**

   Removes the usage of the received amount as a trigger to show the update notification dot on the promotions, due to it being trigger by changes on the conversion from dollar to local currency

**Database changed?**

   No

**Where should the reviewer start?**

- SharePreferencesReferralLocalData

**How should this be manually tested?**

- Go in and out of the promotions and referral screen and check if the new notification updates correctly  

**What are the relevant tickets?**

https://aptoide.atlassian.net/browse/APPC-1377

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass