### PR TITLE
[APPC-1027] Avoid infinite loading on rotation when transfering APPC or Ether

### DIFF
--- a/app/src/main/java/com/asfoundation/wallet/ui/ConfirmationActivity.java
+++ b/app/src/main/java/com/asfoundation/wallet/ui/ConfirmationActivity.java
@@ -74,6 +74,24 @@ public class ConfirmationActivity extends BaseActivity {
         .observe(this, this::onError);
   }
 
+  @Override public boolean onOptionsItemSelected(MenuItem item) {
+    switch (item.getItemId()) {
+      case R.id.action_edit: {
+        viewModel.openGasSettings(ConfirmationActivity.this);
+      }
+      break;
+    }
+    return super.onOptionsItemSelected(item);
+  }
+
+  @Override protected void onActivityResult(int requestCode, int resultCode, Intent intent) {
+    if (requestCode == GasSettingsViewModel.SET_GAS_SETTINGS) {
+      if (resultCode == RESULT_OK) {
+        viewModel.setGasSettings(intent.getParcelableExtra(EXTRA_GAS_SETTINGS));
+      }
+    }
+  }
+
   private void onTransactionBuilder(TransactionBuilder transactionBuilder) {
     fromAddressText.setText(transactionBuilder.fromAddress());
     toAddressText.setText(transactionBuilder.toAddress());
@@ -99,16 +117,6 @@ public class ConfirmationActivity extends BaseActivity {
     getMenuInflater().inflate(R.menu.confirmation_menu, menu);
 
     return super.onCreateOptionsMenu(menu);
-  }
-
-  @Override public boolean onOptionsItemSelected(MenuItem item) {
-    switch (item.getItemId()) {
-      case R.id.action_edit: {
-        viewModel.openGasSettings(ConfirmationActivity.this);
-      }
-      break;
-    }
-    return super.onOptionsItemSelected(item);
   }
 
   private void onProgress(boolean shouldShowProgress) {
@@ -138,6 +146,7 @@ public class ConfirmationActivity extends BaseActivity {
   private void onTransaction(PendingTransaction transaction) {
     Log.d(TAG, "onTransaction() called with: transaction = [" + transaction + "]");
     if (!transaction.isPending()) {
+      viewModel.progressFinished();
       hideDialog();
       dialog = new AlertDialog.Builder(this).setTitle(R.string.transaction_succeeded)
           .setMessage(transaction.getHash())
@@ -171,14 +180,6 @@ public class ConfirmationActivity extends BaseActivity {
         })
         .create();
     dialog.show();
-  }
-
-  @Override protected void onActivityResult(int requestCode, int resultCode, Intent intent) {
-    if (requestCode == GasSettingsViewModel.SET_GAS_SETTINGS) {
-      if (resultCode == RESULT_OK) {
-        viewModel.setGasSettings(intent.getParcelableExtra(EXTRA_GAS_SETTINGS));
-      }
-    }
   }
 
   @Override protected void onResume() {

--- a/app/src/main/java/com/asfoundation/wallet/viewmodel/ConfirmationViewModel.java
+++ b/app/src/main/java/com/asfoundation/wallet/viewmodel/ConfirmationViewModel.java
@@ -45,6 +45,11 @@ public class ConfirmationViewModel extends BaseViewModel {
     super.onCleared();
   }
 
+  @Override protected void onError(Throwable throwable) {
+    super.onError(throwable);
+    Crashlytics.logException(throwable);
+  }
+
   public LiveData<TransactionBuilder> transactionBuilder() {
     return transactionBuilder;
   }
@@ -66,6 +71,10 @@ public class ConfirmationViewModel extends BaseViewModel {
     transactionHash.postValue(pendingTransaction);
   }
 
+  public void progressFinished() {
+    progress.postValue(false);
+  }
+
   public void send() {
     progress.postValue(true);
     disposable = sendTransactionInteract.send(transactionBuilder.getValue())
@@ -82,10 +91,5 @@ public class ConfirmationViewModel extends BaseViewModel {
     }/* else {
         // TODO: Good idea return to SendActivity
         }*/
-  }
-
-  @Override protected void onError(Throwable throwable) {
-    super.onError(throwable);
-    Crashlytics.logException(throwable);
   }
 }


### PR DESCRIPTION
**What does this PR do?**

   Fixes bug when rotating screen on the transaction successful dialog after transferring APPC or Ether.
**NOTE:** Don’t accept until release is merged to dev

**Database changed?**

    No

**Where should the reviewer start?**

ConfirmationActivity.java 

**How should this be manually tested?**

Make a transfer of APPC between 2 wallets and rotate the screen on said dialog

**What are the relevant tickets?**

https://aptoide.atlassian.net/browse/APPC-1027


**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass