### PR TITLE
[APPC-1404] Fixed unaligned top up bonus on larger screen

### DIFF
--- a/app/src/main/res/layout/fragment_top_up_success.xml
+++ b/app/src/main/res/layout/fragment_top_up_success.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
@@ -12,9 +11,8 @@
       android:id="@+id/top_up_success_animation"
       android:layout_width="0dp"
       android:layout_height="0dp"
-      android:visibility="visible"
       app:layout_constraintBottom_toTopOf="@+id/mid_guideline"
-      app:layout_constraintDimensionRatio="W, 6:5"
+      app:layout_constraintDimensionRatio="H, 6:5"
       app:layout_constraintEnd_toEndOf="parent"
       app:layout_constraintHeight_max="0dp"
       app:layout_constraintStart_toStartOf="parent"


### PR DESCRIPTION
**What does this PR do?**

   On larger screens the top up bonus animation on success was showing on larger screens

**Database changed?**

No

**How should this be manually tested?**

On a larger screen and on a normal size screen check if the animation appears correctly

**What are the relevant tickets?**

https://aptoide.atlassian.net/browse/APPC-1404

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass