### PR TITLE
Add target to IAB intent

### DIFF
--- a/billing/src/main/java/com/appcoins/wallet/billing/BillingIntentBuilder.kt
+++ b/billing/src/main/java/com/appcoins/wallet/billing/BillingIntentBuilder.kt
@@ -3,7 +3,6 @@ package com.appcoins.wallet.billing
 import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
-import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.Bundle
 import com.appcoins.wallet.billing.AppcoinsBillingBinder.Companion.EXTRA_BDS_IAP
@@ -50,7 +49,7 @@ class BillingIntentBuilder(val context: Context) {
 
     val value = amount.multiply(BigDecimal.TEN.pow(18))
 
-    var intent = Intent(Intent.ACTION_VIEW)
+    val intent = Intent(Intent.ACTION_VIEW)
     val data = Uri.parse(buildUriString(tokenContractAddress, iabContractAddress, value,
         developerAddress, skuId, BuildConfig.NETWORK_ID, packageName,
         PayloadHelper.getPayload(payload), PayloadHelper.getOrderReference(payload),
@@ -60,30 +59,8 @@ class BillingIntentBuilder(val context: Context) {
     intent.putExtra(AppcoinsBillingBinder.PRODUCT_NAME, skuTitle)
     intent.putExtra(EXTRA_DEVELOPER_PAYLOAD, payload)
     intent.putExtra(EXTRA_BDS_IAP, bdsIap)
-
-    intent = buildTargetIntent(intent)
+    intent.setPackage(context.packageName)
     return PendingIntent.getActivity(context, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT)
-  }
-
-  private fun buildTargetIntent(intent: Intent): Intent {
-    val packageManager = context.packageManager
-    val list = packageManager.queryIntentActivities(intent, PackageManager.MATCH_DEFAULT_ONLY)
-    var devSuffix = ""
-    if (BuildConfig.BUILD_TYPE == "debug") {
-      devSuffix = ".dev"
-    }
-    for (app in list) {
-      if (app.activityInfo.packageName == "cm.aptoide.pt" + devSuffix) {
-        //If there's aptoide installed always choose Aptoide as default to open url
-        intent.setPackage(app.activityInfo.packageName)
-        break
-      } else if (app.activityInfo.packageName == "com.appcoins.wallet" + devSuffix) {
-        //If Aptoide is not installed and wallet is installed then choose Wallet as default to
-        // open url
-        intent.setPackage(app.activityInfo.packageName)
-      }
-    }
-    return intent
   }
 
   private fun buildUriString(tokenContractAddress: String, iabContractAddress: String,


### PR DESCRIPTION
**What does this PR do?**

Adds a setPackage to the IAB intent, so that the user is automatically send to either Aptoide or Wallet.

**Database changed?**

    No

**How should this be manually tested?**

Try to Buy Gas in Trivial Drive with a dev wallet and a prod wallet installed and check if it doesn't pop up the android app suggestions.

**What are the relevant tickets?**

NONE

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass