### PR TITLE
[APPC-1476] Onboarding animation shown when wallet is already created

### DIFF
--- a/app/src/main/java/com/asfoundation/wallet/ui/onboarding/OnboardingPresenter.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/onboarding/OnboardingPresenter.kt
@@ -76,7 +76,7 @@ class OnboardingPresenter(private val disposables: CompositeDisposable,
   }
 
   private fun isWalletCreated(): Observable<Boolean> {
-    return walletCreated.filter { created -> created }
+    return walletCreated.filter { it }
   }
 
   private fun handleRetryClicks() {
@@ -90,24 +90,29 @@ class OnboardingPresenter(private val disposables: CompositeDisposable,
   private fun handleLaterClicks() {
     disposables.add(
         view.getLaterButtonClicks()
-            .doOnNext {
-              handleValidationStatus(WalletValidationStatus.SUCCESS, false)
-            }.subscribe())
+            .doOnNext { handleValidationStatus(WalletValidationStatus.SUCCESS, false) }
+            .subscribe())
   }
 
   private fun handleRedeemButtonClicks() {
     disposables.add(
         view.getRedeemButtonClick()
             .observeOn(viewScheduler)
-            .doOnNext {
-              view.showLoading()
-              handleWalletCreation(skipValidation = false, showAnimation = true)
-            }
+            .doOnNext { handleWalletCreation(skipValidation = false, showAnimation = true) }
             .subscribe()
     )
   }
 
   private fun handleWalletCreation(skipValidation: Boolean, showAnimation: Boolean) {
+    if (walletCreated.hasValue() || !showAnimation) {
+      handleFinishNavigation(skipValidation, false, 0)
+    } else {
+      view.showLoading()
+      handleFinishNavigation(skipValidation, showAnimation, 1)
+    }
+  }
+
+  private fun handleFinishNavigation(skipValidation: Boolean, showAnimation: Boolean, delay: Long) {
     disposables.add(isWalletCreated()
         .flatMapSingle { onboardingInteract.getWalletAddress() }
         .flatMapSingle {
@@ -118,7 +123,7 @@ class OnboardingPresenter(private val disposables: CompositeDisposable,
                 .subscribeOn(networkScheduler)
           }
         }
-        .delay(1, TimeUnit.SECONDS)
+        .delay(delay, TimeUnit.SECONDS)
         .observeOn(viewScheduler)
         .doOnNext { handleValidationStatus(it, showAnimation) }
         .subscribe())
@@ -136,10 +141,7 @@ class OnboardingPresenter(private val disposables: CompositeDisposable,
   private fun handleNextButtonClicks() {
     disposables.add(
         view.getNextButtonClick()
-            .doOnNext {
-              view.showLoading()
-              handleWalletCreation(skipValidation = true, showAnimation = true)
-            }
+            .doOnNext { handleWalletCreation(skipValidation = true, showAnimation = true) }
             .subscribe()
     )
   }

--- a/app/src/main/res/layout/activity_onboarding.xml
+++ b/app/src/main/res/layout/activity_onboarding.xml
@@ -122,7 +122,7 @@
         android:layout_marginEnd="20dp"
         android:gravity="center"
         android:text="@string/terms_and_conditions_error"
-        android:visibility="visible"
+        android:visibility="invisible"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/redeem_bonus"
@@ -137,9 +137,9 @@
         android:layout_marginEnd="20dp"
         android:gravity="center"
         android:orientation="horizontal"
-        app:layout_constraintTop_toBottomOf="@id/terms_conditions_warning"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/terms_conditions_warning"
         >
       <CheckBox
           android:id="@+id/onboarding_checkbox"


### PR DESCRIPTION
**What does this PR do?**

Removes animation of wallet creation when the wallet is already created when the user finishes onboarding 

**Database changed?**

No

**Where should the reviewer start?**

OnBoardingPresenter.kt

**How should this be manually tested?**

- Complete the onboarding fast and check if the animation appears
- Take a bit longer to finish the onboarding and check if no animation appears
- Press I've been invited with no network and then turn on the network to check if it doesn't show animation after pressing retry
- Clear app data, enter the iab view, go through the onboarding fast and check if no animation appears

**What are the relevant tickets?**

https://aptoide.atlassian.net/browse/APPC-1476


**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass