### PR TITLE
[APPC-1477] Improve top up and iab credit card ux

### DIFF
--- a/app/src/main/java/com/asfoundation/wallet/topup/TopUpActivity.kt
+++ b/app/src/main/java/com/asfoundation/wallet/topup/TopUpActivity.kt
@@ -29,6 +29,7 @@ class TopUpActivity : BaseActivity(), TopUpActivityView, ToolbarManager, UriNavi
 
   private lateinit var results: PublishRelay<Uri>
   private lateinit var presenter: TopUpActivityPresenter
+  private var finishingPurchase = false
 
   companion object {
     @JvmStatic
@@ -71,20 +72,20 @@ class TopUpActivity : BaseActivity(), TopUpActivityView, ToolbarManager, UriNavi
   }
 
   override fun onBackPressed() {
-    if (supportFragmentManager.backStackEntryCount != 0) {
-      supportFragmentManager.popBackStack()
-    } else {
-      super.onBackPressed()
+    when {
+      finishingPurchase -> close(true)
+      supportFragmentManager.backStackEntryCount != 0 -> supportFragmentManager.popBackStack()
+      else -> super.onBackPressed()
     }
   }
 
   override fun onOptionsItemSelected(item: MenuItem): Boolean {
     when (item.itemId) {
       android.R.id.home -> {
-        if (supportFragmentManager.backStackEntryCount != 0) {
-          supportFragmentManager.popBackStack()
-        } else {
-          super.onBackPressed()
+        when {
+          finishingPurchase -> close(true)
+          supportFragmentManager.backStackEntryCount != 0 -> supportFragmentManager.popBackStack()
+          else -> super.onBackPressed()
         }
         return true
       }
@@ -124,9 +125,9 @@ class TopUpActivity : BaseActivity(), TopUpActivityView, ToolbarManager, UriNavi
     unlockRotation()
   }
 
-  override fun close() {
+  override fun close(navigateToTransactions: Boolean) {
     if (supportFragmentManager.findFragmentByTag(
-            TopUpSuccessFragment::class.java.simpleName) != null) {
+            TopUpSuccessFragment::class.java.simpleName) != null && navigateToTransactions) {
       TransactionsRouter().open(this, true)
     }
     finish()
@@ -155,5 +156,17 @@ class TopUpActivity : BaseActivity(), TopUpActivityView, ToolbarManager, UriNavi
 
   override fun lockOrientation() {
     requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_LOCKED
+  }
+
+  override fun finishingPurchase() {
+    finishingPurchase = true
+  }
+
+  override fun cancelPayment() {
+    if (supportFragmentManager.backStackEntryCount != 0) {
+      supportFragmentManager.popBackStack()
+    } else {
+      super.onBackPressed()
+    }
   }
 }

--- a/app/src/main/java/com/asfoundation/wallet/topup/TopUpActivity.kt
+++ b/app/src/main/java/com/asfoundation/wallet/topup/TopUpActivity.kt
@@ -71,13 +71,21 @@ class TopUpActivity : BaseActivity(), TopUpActivityView, ToolbarManager, UriNavi
   }
 
   override fun onBackPressed() {
-    close()
+    if (supportFragmentManager.backStackEntryCount != 0) {
+      supportFragmentManager.popBackStack()
+    } else {
+      super.onBackPressed()
+    }
   }
 
   override fun onOptionsItemSelected(item: MenuItem): Boolean {
     when (item.itemId) {
       android.R.id.home -> {
-        close()
+        if (supportFragmentManager.backStackEntryCount != 0) {
+          supportFragmentManager.popBackStack()
+        } else {
+          super.onBackPressed()
+        }
         return true
       }
     }
@@ -91,13 +99,14 @@ class TopUpActivity : BaseActivity(), TopUpActivityView, ToolbarManager, UriNavi
                                  selectedChip: Int, chipValues: List<FiatValue>,
                                  chipAvailability: Boolean) {
     supportFragmentManager.beginTransaction()
-        .replace(R.id.fragment_container,
+        .add(R.id.fragment_container,
             PaymentAuthFragment.newInstance(
                 paymentType,
                 data,
                 selectedCurrency,
                 origin,
                 transactionType, bonusValue, selectedChip, chipValues, chipAvailability))
+        .addToBackStack(PaymentAuthFragment::class.java.simpleName)
         .commit()
   }
 

--- a/app/src/main/java/com/asfoundation/wallet/topup/TopUpActivity.kt
+++ b/app/src/main/java/com/asfoundation/wallet/topup/TopUpActivity.kt
@@ -29,7 +29,7 @@ class TopUpActivity : BaseActivity(), TopUpActivityView, ToolbarManager, UriNavi
 
   private lateinit var results: PublishRelay<Uri>
   private lateinit var presenter: TopUpActivityPresenter
-  private var finishingPurchase = false
+  private var isFinishingPurchase = false
 
   companion object {
     @JvmStatic
@@ -73,7 +73,7 @@ class TopUpActivity : BaseActivity(), TopUpActivityView, ToolbarManager, UriNavi
 
   override fun onBackPressed() {
     when {
-      finishingPurchase -> close(true)
+      isFinishingPurchase -> close(true)
       supportFragmentManager.backStackEntryCount != 0 -> supportFragmentManager.popBackStack()
       else -> super.onBackPressed()
     }
@@ -83,7 +83,7 @@ class TopUpActivity : BaseActivity(), TopUpActivityView, ToolbarManager, UriNavi
     when (item.itemId) {
       android.R.id.home -> {
         when {
-          finishingPurchase -> close(true)
+          isFinishingPurchase -> close(true)
           supportFragmentManager.backStackEntryCount != 0 -> supportFragmentManager.popBackStack()
           else -> super.onBackPressed()
         }
@@ -101,11 +101,7 @@ class TopUpActivity : BaseActivity(), TopUpActivityView, ToolbarManager, UriNavi
                                  chipAvailability: Boolean) {
     supportFragmentManager.beginTransaction()
         .add(R.id.fragment_container,
-            PaymentAuthFragment.newInstance(
-                paymentType,
-                data,
-                selectedCurrency,
-                origin,
+            PaymentAuthFragment.newInstance(paymentType, data, selectedCurrency, origin,
                 transactionType, bonusValue, selectedChip, chipValues, chipAvailability))
         .addToBackStack(PaymentAuthFragment::class.java.simpleName)
         .commit()
@@ -158,8 +154,8 @@ class TopUpActivity : BaseActivity(), TopUpActivityView, ToolbarManager, UriNavi
     requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_LOCKED
   }
 
-  override fun finishingPurchase() {
-    finishingPurchase = true
+  override fun setFinishingPurchase() {
+    isFinishingPurchase = true
   }
 
   override fun cancelPayment() {

--- a/app/src/main/java/com/asfoundation/wallet/topup/TopUpActivityPresenter.kt
+++ b/app/src/main/java/com/asfoundation/wallet/topup/TopUpActivityPresenter.kt
@@ -14,8 +14,8 @@ class TopUpActivityPresenter(private val view: TopUpActivityView) {
                             data: Intent?) {
     if (requestCode == TopUpActivity.WEB_VIEW_REQUEST_CODE) {
       if (resultCode == WebViewActivity.FAIL) {
-        view.close()
-      } else if (resultCode == WebViewActivity.SUCCESS && data!= null) {
+        view.cancelPayment()
+      } else if (resultCode == WebViewActivity.SUCCESS && data != null) {
         view.acceptResult(data.data)
       }
     }

--- a/app/src/main/java/com/asfoundation/wallet/topup/TopUpActivityView.kt
+++ b/app/src/main/java/com/asfoundation/wallet/topup/TopUpActivityView.kt
@@ -17,7 +17,7 @@ interface TopUpActivityView {
 
   fun finish(data: Bundle)
 
-  fun close()
+  fun close(navigateToTransactions: Boolean)
 
   fun acceptResult(uri: Uri)
 
@@ -26,4 +26,7 @@ interface TopUpActivityView {
   fun lockOrientation()
 
   fun unlockRotation()
+
+  fun cancelPayment()
+  fun finishingPurchase()
 }

--- a/app/src/main/java/com/asfoundation/wallet/topup/TopUpActivityView.kt
+++ b/app/src/main/java/com/asfoundation/wallet/topup/TopUpActivityView.kt
@@ -29,5 +29,5 @@ interface TopUpActivityView {
 
   fun cancelPayment()
 
-  fun finishingPurchase()
+  fun setFinishingPurchase()
 }

--- a/app/src/main/java/com/asfoundation/wallet/topup/TopUpActivityView.kt
+++ b/app/src/main/java/com/asfoundation/wallet/topup/TopUpActivityView.kt
@@ -28,5 +28,6 @@ interface TopUpActivityView {
   fun unlockRotation()
 
   fun cancelPayment()
+
   fun finishingPurchase()
 }

--- a/app/src/main/java/com/asfoundation/wallet/topup/TopUpFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/topup/TopUpFragment.kt
@@ -219,6 +219,14 @@ class TopUpFragment : DaggerFragment(), TopUpFragmentView {
     loading.visibility = View.VISIBLE
   }
 
+  override fun hideLoading() {
+    fragment_braintree_credit_card_form.visibility = View.VISIBLE
+    payment_methods.visibility = View.VISIBLE
+    bonus_layout.visibility = View.VISIBLE
+    bonus_msg.visibility = View.VISIBLE
+    loading.visibility = View.INVISIBLE
+  }
+
   override fun showPaymentDetailsForm() {
     payment_methods.visibility = View.GONE
     loading.visibility = View.GONE

--- a/app/src/main/java/com/asfoundation/wallet/topup/TopUpFragmentPresenter.kt
+++ b/app/src/main/java/com/asfoundation/wallet/topup/TopUpFragmentPresenter.kt
@@ -102,6 +102,7 @@ class TopUpFragmentPresenter(private val view: TopUpFragmentView,
           activity?.navigateToPayment(topUpData.paymentMethod!!, topUpData,
               topUpData.selectedCurrency, "BDS",
               "TOPUP", topUpData.bonusValue, view.getSelectedChip(), it, view.getChipAvailability())
+          view.hideLoading()
         }
         .subscribe())
   }

--- a/app/src/main/java/com/asfoundation/wallet/topup/TopUpFragmentView.kt
+++ b/app/src/main/java/com/asfoundation/wallet/topup/TopUpFragmentView.kt
@@ -25,6 +25,8 @@ interface TopUpFragmentView {
 
   fun showLoading()
 
+  fun hideLoading()
+
   fun showPaymentDetailsForm()
 
   fun showPaymentMethods()

--- a/app/src/main/java/com/asfoundation/wallet/topup/TopUpSuccessFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/topup/TopUpSuccessFragment.kt
@@ -114,7 +114,7 @@ class TopUpSuccessFragment : DaggerFragment(), TopUpSuccessFragmentView {
   }
 
   override fun close() {
-    topUpActivityView.close()
+    topUpActivityView.close(true)
   }
 
 

--- a/app/src/main/java/com/asfoundation/wallet/topup/payment/PaymentAuthFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/topup/payment/PaymentAuthFragment.kt
@@ -438,8 +438,8 @@ class PaymentAuthFragment : DaggerFragment(), PaymentAuthView {
     }
   }
 
-  override fun finishingPurchase() {
-    topUpView?.finishingPurchase()
+  override fun setFinishingPurchase() {
+    topUpView?.setFinishingPurchase()
   }
 
   private fun setupChips() {

--- a/app/src/main/java/com/asfoundation/wallet/topup/payment/PaymentAuthFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/topup/payment/PaymentAuthFragment.kt
@@ -271,9 +271,8 @@ class PaymentAuthFragment : DaggerFragment(), PaymentAuthView {
 
   override fun onAttach(context: Context) {
     super.onAttach(context)
-    if (context !is TopUpActivityView) {
-      throw IllegalStateException("Payment Auth fragment must be attached to IAB activity")
-    }
+    check(
+        context is TopUpActivityView) { "Payment Auth fragment must be attached to TopUp activity" }
     topUpView = context
     navigator = PaymentFragmentNavigator((activity as UriNavigator?)!!, topUpView!!)
 

--- a/app/src/main/java/com/asfoundation/wallet/topup/payment/PaymentAuthFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/topup/payment/PaymentAuthFragment.kt
@@ -422,6 +422,10 @@ class PaymentAuthFragment : DaggerFragment(), PaymentAuthView {
     button.isEnabled = valid
   }
 
+  override fun cancelPayment() {
+    topUpView?.cancelPayment()
+  }
+
   override fun showChipsAsDisabled(index: Int) {
     chips_layout.visibility = View.VISIBLE
     setUnselectedChipsDisabledDrawable()
@@ -432,6 +436,10 @@ class PaymentAuthFragment : DaggerFragment(), PaymentAuthView {
       setSelectedChipDisabled(index)
       setSelectedChipText(index)
     }
+  }
+
+  override fun finishingPurchase() {
+    topUpView?.finishingPurchase()
   }
 
   private fun setupChips() {

--- a/app/src/main/java/com/asfoundation/wallet/topup/payment/PaymentAuthPresenter.java
+++ b/app/src/main/java/com/asfoundation/wallet/topup/payment/PaymentAuthPresenter.java
@@ -3,6 +3,7 @@ package com.asfoundation.wallet.topup.payment;
 import android.os.Bundle;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import com.adyen.core.models.Payment;
 import com.adyen.core.models.PaymentMethod;
 import com.adyen.core.utils.AmountUtil;
 import com.appcoins.wallet.billing.BillingMessagesMapper;
@@ -288,6 +289,13 @@ public class PaymentAuthPresenter {
     disposables.add(adyen.getPaymentResult()
         .flatMapCompletable(result -> {
           if (result.isProcessed()) {
+            if (result.getPayment() != null
+                && result.getPayment()
+                .getPaymentStatus() == Payment.PaymentStatus.CANCELLED) {
+              view.cancelPayment();
+              return Completable.complete();
+            }
+            view.finishingPurchase();
             return billingService.authorize(result.getPayment(), result.getPayment()
                 .getPayload());
           }

--- a/app/src/main/java/com/asfoundation/wallet/topup/payment/PaymentAuthPresenter.java
+++ b/app/src/main/java/com/asfoundation/wallet/topup/payment/PaymentAuthPresenter.java
@@ -276,7 +276,7 @@ public class PaymentAuthPresenter {
           waitingResult = true;
         })
         .subscribe(__ -> {
-        }, throwable -> showError(throwable)));
+        }, this::showError));
   }
 
   private void handleErrorDismissEvent() {
@@ -295,7 +295,7 @@ public class PaymentAuthPresenter {
               view.cancelPayment();
               return Completable.complete();
             }
-            view.finishingPurchase();
+            view.setFinishingPurchase();
             return billingService.authorize(result.getPayment(), result.getPayment()
                 .getPayload());
           }

--- a/app/src/main/java/com/asfoundation/wallet/topup/payment/PaymentAuthView.kt
+++ b/app/src/main/java/com/asfoundation/wallet/topup/payment/PaymentAuthView.kt
@@ -45,5 +45,5 @@ interface PaymentAuthView {
 
   fun cancelPayment()
 
-  fun finishingPurchase()
+  fun setFinishingPurchase()
 }

--- a/app/src/main/java/com/asfoundation/wallet/topup/payment/PaymentAuthView.kt
+++ b/app/src/main/java/com/asfoundation/wallet/topup/payment/PaymentAuthView.kt
@@ -42,4 +42,8 @@ interface PaymentAuthView {
   fun updateTopUpButton(valid: Boolean)
 
   fun showChipsAsDisabled(index: Int)
+
+  fun cancelPayment()
+
+  fun finishingPurchase()
 }

--- a/app/src/main/java/com/asfoundation/wallet/topup/payment/PaymentFragmentNavigator.kt
+++ b/app/src/main/java/com/asfoundation/wallet/topup/payment/PaymentFragmentNavigator.kt
@@ -15,7 +15,7 @@ class PaymentFragmentNavigator(private val uriNavigator: UriNavigator,
   }
 
   override fun popViewWithError() {
-    topUpView.close()
+    topUpView.close(false)
   }
 
   override fun navigateToUriForResult(redirectUrl: String) {

--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/AdyenAuthorizationFragment.java
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/AdyenAuthorizationFragment.java
@@ -8,6 +8,7 @@ import android.content.pm.PackageManager;
 import android.graphics.Typeface;
 import android.os.Bundle;
 import android.util.Log;
+import android.view.KeyEvent;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -233,6 +234,9 @@ public class AdyenAuthorizationFragment extends DaggerFragment implements AdyenA
 
       showBonus();
       loadIcon();
+    } else {
+      cancelButton.setText(R.string.back_button);
+      setBackListener(view);
     }
 
     if (isNotBlank(getBonus())) {
@@ -241,7 +245,6 @@ public class AdyenAuthorizationFragment extends DaggerFragment implements AdyenA
     } else {
       lottieTransactionComplete.setAnimation(R.raw.success_animation);
     }
-
     showProduct();
     presenter.present(savedInstanceState);
   }
@@ -253,8 +256,8 @@ public class AdyenAuthorizationFragment extends DaggerFragment implements AdyenA
   }
 
   @Override public void onDestroyView() {
+    iabView.enableBack();
     presenter.stop();
-
     validationSubject = null;
     progressBar = null;
     productIcon = null;
@@ -403,7 +406,7 @@ public class AdyenAuthorizationFragment extends DaggerFragment implements AdyenA
     errorMessage.setText(R.string.notification_no_network_poa);
   }
 
-  @NotNull @Override public Observable<Object> cancelEvent() {
+  @NotNull @Override public Observable<Object> backEvent() {
     return RxView.clicks(cancelButton)
         .mergeWith(backButton);
   }
@@ -545,6 +548,19 @@ public class AdyenAuthorizationFragment extends DaggerFragment implements AdyenA
         .setPadding(0, 4, 0, 0);
 
     presenter.sendPaymentMethodDetailsEvent(PAYMENT_METHOD_CC);
+  }
+
+  private void setBackListener(View view) {
+    iabView.disableBack();
+    view.setFocusableInTouchMode(true);
+    view.requestFocus();
+    view.setOnKeyListener((view1, i, keyEvent) -> {
+      if (keyEvent.getAction() == KeyEvent.ACTION_DOWN
+          && keyEvent.getKeyCode() == KeyEvent.KEYCODE_BACK) {
+        backButton.accept(true);
+      }
+      return true;
+    });
   }
 
   private PaymentDetails getPaymentDetails(String publicKey, String generationTime) {

--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/AdyenAuthorizationFragment.java
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/AdyenAuthorizationFragment.java
@@ -496,7 +496,7 @@ public class AdyenAuthorizationFragment extends DaggerFragment implements AdyenA
 
   @Override public void showMoreMethods() {
     KeyboardUtils.hideKeyboard(mainView);
-    iabView.showPaymentMethodsView(PaymentMethodsView.SelectedPaymentMethod.CREDIT_CARD);
+    iabView.showPaymentMethodsView();
   }
 
   @Override public Observable<Boolean> onValidFieldStateChange() {

--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/AdyenAuthorizationPresenter.java
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/AdyenAuthorizationPresenter.java
@@ -119,7 +119,7 @@ public class AdyenAuthorizationPresenter {
 
     handleAdyenPaymentResult();
 
-    handleCancel();
+    handleBack();
 
     handleMorePaymentMethodClicks();
 
@@ -370,10 +370,16 @@ public class AdyenAuthorizationPresenter {
         }, this::showError));
   }
 
-  private void handleCancel() {
-    disposables.add(view.cancelEvent()
+  private void handleBack() {
+    disposables.add(view.backEvent()
         .observeOn(viewScheduler)
-        .doOnNext(__ -> close())
+        .doOnNext(__ -> {
+          if (isPreSelected) {
+            close();
+          } else {
+            view.showMoreMethods();
+          }
+        })
         .subscribe(__ -> {
         }, this::showError));
   }

--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/AdyenAuthorizationPresenter.java
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/AdyenAuthorizationPresenter.java
@@ -3,6 +3,7 @@ package com.asfoundation.wallet.ui.iab;
 import android.os.Bundle;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import com.adyen.core.models.Payment;
 import com.adyen.core.models.PaymentMethod;
 import com.appcoins.wallet.bdsbilling.Billing;
 import com.appcoins.wallet.billing.BillingMessagesMapper;
@@ -360,6 +361,12 @@ public class AdyenAuthorizationPresenter {
     disposables.add(adyen.getPaymentResult()
         .flatMapCompletable(result -> {
           if (result.isProcessed()) {
+            if (result.getPayment() != null
+                && result.getPayment()
+                .getPaymentStatus() == Payment.PaymentStatus.CANCELLED) {
+              view.showMoreMethods();
+              return Completable.complete();
+            }
             return billingService.authorize(result.getPayment(), result.getPayment()
                 .getPayload());
           }

--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/AdyenAuthorizationView.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/AdyenAuthorizationView.kt
@@ -17,7 +17,7 @@ interface AdyenAuthorizationView {
   fun paymentMethodDetailsEvent(): Observable<PaymentDetails>
   fun changeCardMethodDetailsEvent(): Observable<PaymentMethod>
   fun showNetworkError()
-  fun cancelEvent(): Observable<Any>
+  fun backEvent(): Observable<Any>
   fun showCvcView(amount: Amount, paymentMethod: PaymentMethod)
   fun showCreditCardView(paymentMethod: PaymentMethod, amount: Amount, cvcStatus: Boolean,
                          allowSave: Boolean, publicKey: String, generationTime: String)

--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/EarnAppcoinsFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/EarnAppcoinsFragment.kt
@@ -59,8 +59,8 @@ class EarnAppcoinsFragment : DaggerFragment(), EarnAppcoinsView {
     return RxView.clicks(buy_button)
   }
 
-  override fun navigateBack(preSelectedMethod: PaymentMethodsView.SelectedPaymentMethod) {
-    iabView.showPaymentMethodsView(preSelectedMethod)
+  override fun navigateBack() {
+    iabView.showPaymentMethodsView()
   }
 
   override fun backPressed(): Observable<Any> {

--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/EarnAppcoinsPresenter.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/EarnAppcoinsPresenter.kt
@@ -22,7 +22,7 @@ class EarnAppcoinsPresenter(private val view: EarnAppcoinsView,
   private fun handleBackClick() {
     disposables.add(Observable.merge(view.backButtonClick(), view.backPressed())
         .observeOn(viewScheduler)
-        .doOnNext { view.navigateBack(PaymentMethodsView.SelectedPaymentMethod.EARN_APPC) }
+        .doOnNext { view.navigateBack() }
         .subscribe({}, { it.printStackTrace() }))
   }
 

--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/EarnAppcoinsView.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/EarnAppcoinsView.kt
@@ -6,7 +6,7 @@ interface EarnAppcoinsView {
 
   fun backButtonClick(): Observable<Any>
   fun discoverButtonClick(): Observable<Any>
-  fun navigateBack(preSelectedMethod: PaymentMethodsView.SelectedPaymentMethod)
+  fun navigateBack()
   fun navigateToAptoide()
   fun backPressed(): Observable<Any>
 }

--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/IabActivity.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/IabActivity.kt
@@ -72,7 +72,7 @@ class IabActivity : BaseActivity(), IabView, UriNavigator {
 
     if (requestCode == WEB_VIEW_REQUEST_CODE) {
       if (resultCode == WebViewActivity.FAIL) {
-        finish()
+        showPaymentMethodsView()
       } else if (resultCode == SUCCESS) {
         results!!.accept(Objects.requireNonNull(data!!.data, "Intent data cannot be null!"))
       }
@@ -159,7 +159,7 @@ class IabActivity : BaseActivity(), IabView, UriNavigator {
         .commit()
   }
 
-  override fun showPaymentMethodsView(preSelectedMethod: PaymentMethodsView.SelectedPaymentMethod) {
+  override fun showPaymentMethodsView() {
     val isDonation = TransactionData.TransactionType.DONATION.name
         .equals(transaction?.type, ignoreCase = true)
     supportFragmentManager.beginTransaction()

--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/IabPresenter.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/IabPresenter.kt
@@ -31,7 +31,7 @@ class IabPresenter(private val view: IabView, private val autoUpdateInteract: Au
             updateModel.updateVersionCode, updateModel.updateMinSdk)) {
       view.showUpdateRequiredView()
     } else {
-      view.showPaymentMethodsView(PaymentMethodsView.SelectedPaymentMethod.CREDIT_CARD)
+      view.showPaymentMethodsView()
     }
   }
 }

--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/IabView.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/IabView.kt
@@ -28,7 +28,7 @@ interface IabView {
                        type: String, amount: BigDecimal, callbackUrl: String?,
                        orderReference: String?, payload: String?)
 
-  fun showPaymentMethodsView(preSelectedMethod: PaymentMethodsView.SelectedPaymentMethod)
+  fun showPaymentMethodsView()
   fun showShareLinkPayment(domain: String, skuId: String?, originalAmount: String?,
                            originalCurrency: String?, amount: BigDecimal, type: String,
                            selectedPaymentMethod: String)

--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/MergedAppcoinsFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/MergedAppcoinsFragment.kt
@@ -359,9 +359,8 @@ class MergedAppcoinsFragment : DaggerFragment(), MergedAppcoinsView {
     iabView.showAppcoinsCreditsPayment(appcAmount)
   }
 
-  override fun navigateToPaymentMethods(
-      preSelectedMethod: PaymentMethodsView.SelectedPaymentMethod) {
-    iabView.showPaymentMethodsView(preSelectedMethod)
+  override fun navigateToPaymentMethods() {
+    iabView.showPaymentMethodsView()
   }
 
   @SuppressLint("SetTextI18n")

--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/MergedAppcoinsPresenter.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/MergedAppcoinsPresenter.kt
@@ -51,9 +51,7 @@ class MergedAppcoinsPresenter(private val view: MergedAppcoinsView,
 
   private fun handleBackClick() {
     disposables.add(Observable.merge(view.backClick(), view.backPressed())
-        .doOnNext {
-          view.navigateToPaymentMethods(PaymentMethodsView.SelectedPaymentMethod.MERGED_APPC)
-        }
+        .doOnNext { view.navigateToPaymentMethods() }
         .subscribe({}, { showError(it) }))
   }
 

--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/MergedAppcoinsView.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/MergedAppcoinsView.kt
@@ -14,7 +14,7 @@ interface MergedAppcoinsView {
   fun backPressed(): Observable<Any>
   fun navigateToAppcPayment()
   fun navigateToCreditsPayment()
-  fun navigateToPaymentMethods(preSelectedMethod: PaymentMethodsView.SelectedPaymentMethod)
+  fun navigateToPaymentMethods()
   fun updateBalanceValues(appcFiat: FiatValue, creditsFiat: FiatValue)
   fun showWalletBlocked()
   fun showLoading()

--- a/app/src/main/res/layout/fragment_top_up.xml
+++ b/app/src/main/res/layout/fragment_top_up.xml
@@ -9,6 +9,7 @@
   <androidx.constraintlayout.widget.ConstraintLayout
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
+      android:background="@color/activity_background_color"
       >
     <TextView
         android:id="@+id/main_currency_code"


### PR DESCRIPTION
**What does this PR do?**

Adds the possibility to go back to payment methods view in both top up and iab after the users is in the credit card view or paypal.

**Database changed?**

No

**Where should the reviewer start?**

-TopUpFragment.kt
-AdyenAuthorizationFragment.java

**How should this be manually tested?**

Go to the credit card view in both iab and top up and press back(phone back button and app back button)
Check if the pre selected works correctly 

**What are the relevant tickets?**

https://aptoide.atlassian.net/browse/APPC-1477

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass