### PR TITLE
[APPC-1482] Changed order in which app notifications appear

### DIFF
--- a/app/src/main/java/com/asfoundation/wallet/interact/CardNotificationsInteractor.kt
+++ b/app/src/main/java/com/asfoundation/wallet/interact/CardNotificationsInteractor.kt
@@ -23,8 +23,8 @@ class CardNotificationsInteractor(
         Function3 { referralNotification: CardNotification, updateNotification: CardNotification, backupNotification: CardNotification ->
           val list = ArrayList<CardNotification>()
           if (referralNotification !is EmptyNotification) list.add(referralNotification)
-          if (updateNotification !is EmptyNotification) list.add(updateNotification)
           if (backupNotification !is EmptyNotification) list.add(backupNotification)
+          if (updateNotification !is EmptyNotification) list.add(updateNotification)
           list
         })
   }


### PR DESCRIPTION
**What does this PR do?**

  BackUp app notification now appears before the auto update app notification

**Database changed?**

  No

**How should this be manually tested?**

Check if the backup notification appears before the autoupdate notification

**What are the relevant tickets?**

https://aptoide.atlassian.net/browse/APPC-1482

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass