### PR TITLE
[bugfix/APPC-1025] -  Transactions icons misplacing fix

### DIFF
--- a/app/src/main/java/com/asfoundation/wallet/ui/TransactionsActivity.java
+++ b/app/src/main/java/com/asfoundation/wallet/ui/TransactionsActivity.java
@@ -117,7 +117,7 @@ public class TransactionsActivity extends BaseNavigationActivity implements View
     emptyTransactionsSubject = PublishSubject.create();
     paddingDp = (int) (80 * getResources().getDisplayMetrics().density);
     adapter = new TransactionsAdapter(this::onTransactionClick, this::onApplicationClick,
-        this::onNotificationClick);
+        this::onNotificationClick, getResources());
     SwipeRefreshLayout refreshLayout = findViewById(R.id.refresh_layout);
     systemView = findViewById(R.id.system_view);
     list = findViewById(R.id.list);

--- a/app/src/main/java/com/asfoundation/wallet/ui/widget/adapter/TransactionsAdapter.java
+++ b/app/src/main/java/com/asfoundation/wallet/ui/widget/adapter/TransactionsAdapter.java
@@ -1,5 +1,6 @@
 package com.asfoundation.wallet.ui.widget.adapter;
 
+import android.content.res.Resources;
 import android.os.Bundle;
 import android.view.ViewGroup;
 import androidx.recyclerview.widget.RecyclerView;
@@ -64,13 +65,16 @@ public class TransactionsAdapter extends RecyclerView.Adapter<BinderViewHolder> 
 
   private Wallet wallet;
   private NetworkInfo network;
+  private Resources resources;
 
   public TransactionsAdapter(OnTransactionClickListener onTransactionClickListener,
       Action1<AppcoinsApplication> applicationClickListener,
-      Action2<CardNotification, CardNotificationAction> referralNotificationClickListener) {
+      Action2<CardNotification, CardNotificationAction> referralNotificationClickListener,
+      Resources resources) {
     this.onTransactionClickListener = onTransactionClickListener;
     this.applicationClickListener = applicationClickListener;
     this.referralNotificationClickListener = referralNotificationClickListener;
+    this.resources = resources;
   }
 
   @Override public BinderViewHolder<?> onCreateViewHolder(ViewGroup parent, int viewType) {
@@ -78,7 +82,8 @@ public class TransactionsAdapter extends RecyclerView.Adapter<BinderViewHolder> 
     switch (viewType) {
       case TransactionHolder.VIEW_TYPE:
         holder =
-            new TransactionHolder(R.layout.item_transaction, parent, onTransactionClickListener);
+            new TransactionHolder(R.layout.item_transaction, parent, onTransactionClickListener,
+                resources);
         break;
       case TransactionDateHolder.VIEW_TYPE:
         holder = new TransactionDateHolder(R.layout.item_transactions_date_head, parent);

--- a/app/src/main/java/com/asfoundation/wallet/ui/widget/holder/TransactionHolder.java
+++ b/app/src/main/java/com/asfoundation/wallet/ui/widget/holder/TransactionHolder.java
@@ -1,5 +1,6 @@
 package com.asfoundation.wallet.ui.widget.holder;
 
+import android.content.res.Resources;
 import android.os.Bundle;
 import android.text.TextUtils;
 import android.view.View;
@@ -38,8 +39,10 @@ public class TransactionHolder extends BinderViewHolder<Transaction>
   private Transaction transaction;
   private String defaultAddress;
   private OnTransactionClickListener onTransactionClickListener;
+  private Resources resources;
 
-  public TransactionHolder(int resId, ViewGroup parent, OnTransactionClickListener listener) {
+  public TransactionHolder(int resId, ViewGroup parent, OnTransactionClickListener listener,
+      Resources resources) {
     super(resId, parent);
 
     srcImage = findViewById(R.id.img);
@@ -52,6 +55,7 @@ public class TransactionHolder extends BinderViewHolder<Transaction>
     onTransactionClickListener = listener;
 
     itemView.setOnClickListener(this);
+    this.resources = resources;
   }
 
   @Override public void bind(@Nullable Transaction data, @NonNull Bundle addition) {
@@ -75,7 +79,8 @@ public class TransactionHolder extends BinderViewHolder<Transaction>
   }
 
   private String extractTo(Transaction transaction) {
-    if (transaction.getOperations() != null && !transaction.getOperations()
+    if (transaction.getOperations() != null
+        && !transaction.getOperations()
         .isEmpty()
         && transaction.getOperations()
         .get(0) != null
@@ -91,7 +96,8 @@ public class TransactionHolder extends BinderViewHolder<Transaction>
   }
 
   private String extractFrom(Transaction transaction) {
-    if (transaction.getOperations() != null && !transaction.getOperations()
+    if (transaction.getOperations() != null
+        && !transaction.getOperations()
         .isEmpty()
         && transaction.getOperations()
         .get(0) != null
@@ -179,12 +185,13 @@ public class TransactionHolder extends BinderViewHolder<Transaction>
     }
 
     int finalTransactionTypeIcon = transactionTypeIcon;
+    int transactionImageSize = (int) resources.getDimension(R.dimen.transaction_img_size_inside);
     Picasso.with(getContext())
         .load(uri)
         .transform(new CircleTransformation())
         .placeholder(finalTransactionTypeIcon)
         .error(transactionTypeIcon)
-        .fit()
+        .resize(transactionImageSize, transactionImageSize)
         .into(srcImage, new Callback() {
           @Override public void onSuccess() {
             ((ImageView) typeIcon.findViewById(R.id.icon)).setImageResource(


### PR DESCRIPTION
**What does this PR do?**

   This PR fixes the issues where, sometimes, the transactions icons would be misplaced.


**Database changed?**

   No


**Where should the reviewer start?**

-  TransactionHolder.java


**How should this be manually tested?**

While on TransactionsActivity, refresh the transactions list.

  Flow on how to test this or QA Tickets related to this use-case: [APPC-1025](https://aptoide.atlassian.net/browse/APPC-1025)


**What are the relevant tickets?**

  Tickets related to this pull-request: [APPC-1025](https://aptoide.atlassian.net/browse/APPC-1025)


**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass