### PR TITLE
[APPC-1514] New backup rule implemented

### DIFF
--- a/app/src/main/java/com/asfoundation/wallet/repository/PreferencesRepositoryType.kt
+++ b/app/src/main/java/com/asfoundation/wallet/repository/PreferencesRepositoryType.kt
@@ -30,4 +30,6 @@ interface PreferencesRepositoryType {
   fun isWalletImportBackup(walletAddress: String): Boolean
   fun setWalletImportBackup(walletAddress: String)
   fun removeWalletImportBackup(walletAddress: String)
+  fun hasShownBackup(walletAddress: String): Boolean
+  fun setHasShownBackup(walletAddress: String, hasShown: Boolean)
 }

--- a/app/src/main/java/com/asfoundation/wallet/repository/SharedPreferencesRepository.kt
+++ b/app/src/main/java/com/asfoundation/wallet/repository/SharedPreferencesRepository.kt
@@ -131,6 +131,16 @@ class SharedPreferencesRepository(context: Context) : PreferencesRepositoryType 
         .apply()
   }
 
+  override fun hasShownBackup(walletAddress: String): Boolean {
+    return pref.getBoolean(HAS_SHOWN_BACKUP + walletAddress, false)
+  }
+
+  override fun setHasShownBackup(walletAddress: String, hasShown: Boolean) {
+    pref.edit()
+        .putBoolean(HAS_SHOWN_BACKUP + walletAddress, hasShown)
+        .apply()
+  }
+
   companion object {
 
     private const val CURRENT_ACCOUNT_ADDRESS_KEY = "current_account_address"
@@ -144,5 +154,6 @@ class SharedPreferencesRepository(context: Context) : PreferencesRepositoryType 
     private const val WALLET_VERIFIED = "wallet_verified_"
     private const val PREF_WALLET = "pref_wallet"
     private const val WALLET_IMPORT_BACKUP = "wallet_import_backup_"
+    private const val HAS_SHOWN_BACKUP = "has_shown_backup_"
   }
 }


### PR DESCRIPTION
**What does this PR do?**

 Once reached one of the rules, we only hide the notification after the user backups or dismisses it.

**Database changed?**

 No

**Where should the reviewer start?**

BackUpInteract.kt

**How should this be manually tested?**

TopUp 10€, spend something, check if the notification still appears

**What are the relevant tickets?**

https://aptoide.atlassian.net/browse/APPC-1514


**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass