### PR TITLE
[MOB-176] - Fix 2 loading screens flicker when buying with APPC/APPC-C

### DIFF
--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/MergedAppcoinsFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/MergedAppcoinsFragment.kt
@@ -206,6 +206,9 @@ class MergedAppcoinsFragment : DaggerFragment(), MergedAppcoinsView {
 
   override fun hideLoading() {
     loading_view?.visibility = GONE
+  }
+
+  override fun showPaymentMethods() {
     payment_methods?.visibility = VISIBLE
   }
 

--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/MergedAppcoinsPresenter.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/MergedAppcoinsPresenter.kt
@@ -79,6 +79,7 @@ class MergedAppcoinsPresenter(private val view: MergedAppcoinsView,
   private fun showBlockedError(): Completable {
     return Completable.fromAction {
       view.hideLoading()
+      view.showPaymentMethods()
       view.showWalletBlocked()
     }
   }

--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/MergedAppcoinsView.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/MergedAppcoinsView.kt
@@ -19,4 +19,5 @@ interface MergedAppcoinsView {
   fun showWalletBlocked()
   fun showLoading()
   fun hideLoading()
+  fun showPaymentMethods()
 }

--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/PaymentMethodsPresenter.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/PaymentMethodsPresenter.kt
@@ -121,7 +121,6 @@ class PaymentMethodsPresenter(
                 }
               } else {
                 Completable.fromAction {
-                  view.hideLoading()
                   view.showCredits()
                 }
               }


### PR DESCRIPTION
**What does this PR do?**

   This PR fixes the 2 loading screens flicker when making a purchase with APPC or APPC-C.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] MergedAppcoinsPresenter.kt
- [ ] MergedAppcoinsFragment.kt
- [ ] MergedAppcoinsView.kt

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [MOB-176](https://aptoide.atlassian.net/browse/MOB-176)

**What are the relevant tickets?**

  Tickets related to this pull-request: [MOB-176](https://aptoide.atlassian.net/browse/MOB-176)



**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass