### PR TITLE
[MOB-308] Fixed autfill creditcard not working. Fixed change card data after press buy

### DIFF
--- a/app/src/main/java/com/asfoundation/wallet/billing/adyen/AdyenPaymentFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/billing/adyen/AdyenPaymentFragment.kt
@@ -51,8 +51,7 @@ import kotlinx.android.synthetic.main.adyen_credit_card_layout.fragment_credit_c
 import kotlinx.android.synthetic.main.adyen_credit_card_pre_selected.*
 import kotlinx.android.synthetic.main.dialog_buy_buttons_adyen_error.*
 import kotlinx.android.synthetic.main.dialog_buy_buttons_payment_methods.*
-import kotlinx.android.synthetic.main.fragment_adyen_error.layout_support_logo
-import kotlinx.android.synthetic.main.fragment_adyen_error.layout_support_icn
+import kotlinx.android.synthetic.main.fragment_adyen_error.*
 import kotlinx.android.synthetic.main.fragment_adyen_error.view.*
 import kotlinx.android.synthetic.main.fragment_iab_error.*
 import kotlinx.android.synthetic.main.fragment_iab_error.view.*
@@ -95,7 +94,7 @@ class AdyenPaymentFragment : DaggerFragment(), AdyenPaymentView {
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     backButton = PublishRelay.create<Boolean>()
-    paymentDataSubject = ReplaySubject.create<AdyenCardWrapper>()
+    paymentDataSubject = ReplaySubject.createWithSize<AdyenCardWrapper>(1)
     paymentDetailsSubject = PublishSubject.create<RedirectComponentModel>()
     val navigator = FragmentNavigator(activity as UriNavigator?, iabView)
     compositeDisposable = CompositeDisposable()
@@ -150,9 +149,7 @@ class AdyenPaymentFragment : DaggerFragment(), AdyenPaymentView {
     setStoredPaymentInformation(isStored)
   }
 
-  override fun retrievePaymentData(): Observable<AdyenCardWrapper> {
-    return paymentDataSubject!!
-  }
+  override fun retrievePaymentData() = paymentDataSubject!!
 
   override fun onSaveInstanceState(outState: Bundle) {
     super.onSaveInstanceState(outState)

--- a/app/src/main/java/com/asfoundation/wallet/billing/adyen/AdyenPaymentPresenter.kt
+++ b/app/src/main/java/com/asfoundation/wallet/billing/adyen/AdyenPaymentPresenter.kt
@@ -15,11 +15,9 @@ import com.asfoundation.wallet.ui.iab.InAppPurchaseInteractor
 import com.asfoundation.wallet.ui.iab.Navigator
 import com.asfoundation.wallet.ui.iab.PaymentMethodsView
 import io.reactivex.Completable
-import io.reactivex.Observable
 import io.reactivex.Scheduler
 import io.reactivex.Single
 import io.reactivex.disposables.CompositeDisposable
-import io.reactivex.functions.BiFunction
 import java.math.BigDecimal
 import java.util.concurrent.TimeUnit
 
@@ -157,31 +155,35 @@ class AdyenPaymentPresenter(private val view: AdyenPaymentView,
   }
 
   private fun handleBuyClick(priceAmount: BigDecimal, priceCurrency: String) {
-    disposables.add(Observable.zip(view.buyButtonClicked(), view.retrievePaymentData(),
-        BiFunction { _: Any, adyenCard: AdyenCardWrapper -> adyenCard })
-        .observeOn(viewScheduler)
-        .doOnNext {
-          view.showLoading()
-          view.hideKeyboard()
-          view.lockRotation()
-        }
-        .observeOn(networkScheduler)
-        .flatMapSingle { adyenCard ->
-          transactionBuilder
-              .flatMap {
-                adyenPaymentInteractor.makePayment(adyenCard.cardPaymentMethod,
-                    adyenCard.shouldStoreCard, returnUrl,
-                    priceAmount.toString(), priceCurrency, it.orderReference,
-                    mapPaymentToService(paymentType).transactionType, origin, domain, it.payload,
-                    it.skuId, it.callbackUrl, it.type, it.toAddress())
-              }
-        }
-        .observeOn(viewScheduler)
-        .flatMapCompletable {
-          handlePaymentResult(it.uid, it.resultCode, it.refusalCode, it.refusalReason, it.status,
-              it.error)
-        }
-        .subscribe())
+    disposables.add(
+        view.buyButtonClicked()
+            .flatMapSingle {
+              view.retrievePaymentData()
+                  .firstOrError()
+            }
+            .observeOn(viewScheduler)
+            .doOnNext {
+              view.showLoading()
+              view.hideKeyboard()
+              view.lockRotation()
+            }
+            .observeOn(networkScheduler)
+            .flatMapSingle { adyenCard ->
+              transactionBuilder
+                  .flatMap {
+                    adyenPaymentInteractor.makePayment(adyenCard.cardPaymentMethod,
+                        adyenCard.shouldStoreCard, returnUrl, priceAmount.toString(), priceCurrency,
+                        it.orderReference, mapPaymentToService(paymentType).transactionType, origin,
+                        domain, it.payload, it.skuId, it.callbackUrl, it.type, it.toAddress())
+                  }
+            }
+            .observeOn(viewScheduler)
+            .flatMapCompletable {
+              handlePaymentResult(it.uid, it.resultCode, it.refusalCode, it.refusalReason,
+                  it.status,
+                  it.error)
+            }
+            .subscribe())
   }
 
   private fun handlePaymentResult(uid: String, resultCode: String,

--- a/app/src/main/java/com/asfoundation/wallet/billing/adyen/AdyenPaymentView.kt
+++ b/app/src/main/java/com/asfoundation/wallet/billing/adyen/AdyenPaymentView.kt
@@ -4,6 +4,7 @@ import android.net.Uri
 import android.os.Bundle
 import com.adyen.checkout.base.model.payments.response.Action
 import io.reactivex.Observable
+import io.reactivex.subjects.ReplaySubject
 import java.math.BigDecimal
 
 interface AdyenPaymentView {
@@ -38,7 +39,7 @@ interface AdyenPaymentView {
       paymentMethod: com.adyen.checkout.base.model.paymentmethods.PaymentMethod, isStored: Boolean,
       forget: Boolean, savedInstance: Bundle?)
 
-  fun retrievePaymentData(): Observable<AdyenCardWrapper>
+  fun retrievePaymentData(): ReplaySubject<AdyenCardWrapper>
 
   fun showSpecificError(stringRes: Int)
 

--- a/app/src/main/java/com/asfoundation/wallet/topup/payment/AdyenTopUpFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/topup/payment/AdyenTopUpFragment.kt
@@ -47,8 +47,8 @@ import io.reactivex.subjects.PublishSubject
 import io.reactivex.subjects.ReplaySubject
 import kotlinx.android.synthetic.main.adyen_credit_card_pre_selected.*
 import kotlinx.android.synthetic.main.default_value_chips_layout.*
-import kotlinx.android.synthetic.main.fragment_adyen_error.layout_support_logo
 import kotlinx.android.synthetic.main.fragment_adyen_error.layout_support_icn
+import kotlinx.android.synthetic.main.fragment_adyen_error.layout_support_logo
 import kotlinx.android.synthetic.main.fragment_adyen_error.view.*
 import kotlinx.android.synthetic.main.fragment_adyen_error_top_up.*
 import kotlinx.android.synthetic.main.fragment_top_up.*
@@ -97,7 +97,7 @@ class AdyenTopUpFragment : DaggerFragment(), AdyenTopUpView {
     super.onCreate(savedInstanceState)
     keyboardTopUpRelay = PublishRelay.create()
     validationSubject = PublishSubject.create()
-    paymentDataSubject = ReplaySubject.create<AdyenCardWrapper>()
+    paymentDataSubject = ReplaySubject.createWithSize<AdyenCardWrapper>(1)
     paymentDetailsSubject = PublishSubject.create<RedirectComponentModel>()
 
     presenter =


### PR DESCRIPTION

**What does this PR do?**

   This PR fixes a scenario in the credit card view ( topup and iap) that was causing tha autofill to not work and also fixes a bug where the buy button was being press without the user choice

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] AdyenPaymentFragment.kt
- [ ] AdyenPaymentPresenter.kt
- [ ] AdyenPaymentView.kt
- [ ] AdyenTopUpFragment.kt
- [ ] AdyenTopUpPresenter.kt

**How should this be manually tested?**
1. Test if autfill credit card works
2. Test if after using a wrong cvv the next change won't make teh user submit the payment request

  Flow on how to test this or QA Tickets related to this use-case: [MOB-308](https://aptoide.atlassian.net/browse/MOB-308)

**What are the relevant tickets?**

  Tickets related to this pull-request: [MOB-308](https://aptoide.atlassian.net/browse/MOB-308)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new libs, new keys, etc.)




**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass