### PR TITLE
[MOB 317] Fix crash for local payments in landscape

### DIFF
--- a/app/src/main/res/layout-land/local_payment_layout.xml
+++ b/app/src/main/res/layout-land/local_payment_layout.xml
@@ -31,7 +31,7 @@
       layout="@layout/pending_user_payment_view"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
-      android:visibility="visible"
+      android:visibility="gone"
       />
 
   <FrameLayout


### PR DESCRIPTION

**What does this PR do?**

Set visibility to gone in the animation view for local payments in landscape
