### PR TITLE
[MOB-456] - Remove Bonus information box for APPC and APPC-C

### DIFF
--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/PaymentMethodsFragment.java
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/PaymentMethodsFragment.java
@@ -508,6 +508,7 @@ public class PaymentMethodsFragment extends DaggerFragment implements PaymentMet
   @Override public void hideBonus() {
     bonusView.setVisibility(View.INVISIBLE);
     bonusMsg.setVisibility(View.INVISIBLE);
+    hideBottomSeparator();
   }
 
   @Override public void replaceBonus() {
@@ -646,7 +647,6 @@ public class PaymentMethodsFragment extends DaggerFragment implements PaymentMet
       preSelectedDescription.setVisibility(View.VISIBLE);
       preSelectedNameSingle.setVisibility(View.GONE);
       hideBonus();
-      hideBottomSeparator();
     } else {
       preSelectedName.setVisibility(View.VISIBLE);
       preSelectedName.setText(paymentMethod.getLabel());

--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/PaymentMethodsFragment.java
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/PaymentMethodsFragment.java
@@ -171,8 +171,8 @@ public class PaymentMethodsFragment extends DaggerFragment implements PaymentMet
     presenter = new PaymentMethodsPresenter(this, appPackage, AndroidSchedulers.mainThread(),
         Schedulers.io(), new CompositeDisposable(), inAppPurchaseInteractor, balanceInteractor,
         inAppPurchaseInteractor.getBillingMessagesMapper(), bdsPendingTransactionService, billing,
-        analytics, analyticsSetup, isBds, developerPayload, uri, gamification, transaction, paymentMethodsMapper,
-        walletBlockedInteract, transactionValue);
+        analytics, analyticsSetup, isBds, developerPayload, uri, gamification, transaction,
+        paymentMethodsMapper, walletBlockedInteract, transactionValue);
   }
 
   @Nullable @Override
@@ -505,6 +505,11 @@ public class PaymentMethodsFragment extends DaggerFragment implements PaymentMet
     }
   }
 
+  @Override public void hideBonus() {
+    bonusView.setVisibility(View.INVISIBLE);
+    bonusMsg.setVisibility(View.INVISIBLE);
+  }
+
   @Override public void replaceBonus() {
     bonusView.setVisibility(View.INVISIBLE);
     bonusMsg.setVisibility(View.INVISIBLE);
@@ -517,9 +522,7 @@ public class PaymentMethodsFragment extends DaggerFragment implements PaymentMet
     iabView.showWalletBlocked();
   }
 
-  private void hideBonus() {
-    bonusView.setVisibility(View.GONE);
-    bonusMsg.setVisibility(View.GONE);
+  private void hideBottomSeparator() {
     if (bottomSeparator != null) {
       bottomSeparator.setVisibility(View.INVISIBLE);
     }
@@ -643,6 +646,7 @@ public class PaymentMethodsFragment extends DaggerFragment implements PaymentMet
       preSelectedDescription.setVisibility(View.VISIBLE);
       preSelectedNameSingle.setVisibility(View.GONE);
       hideBonus();
+      hideBottomSeparator();
     } else {
       preSelectedName.setVisibility(View.VISIBLE);
       preSelectedName.setText(paymentMethod.getLabel());

--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/PaymentMethodsPresenter.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/PaymentMethodsPresenter.kt
@@ -221,15 +221,17 @@ class PaymentMethodsPresenter(
   }
 
   private fun setupUi(transactionValue: Double) {
-    disposables.add(waitForOngoingPurchase(transaction.skuId).subscribeOn(networkThread).andThen(
-        inAppPurchaseInteractor.convertToLocalFiat(transactionValue).subscribeOn(networkThread)
-            .flatMapCompletable { fiatValue ->
-              getPaymentMethods(fiatValue)
-                  .observeOn(viewScheduler)
-                  .flatMapCompletable { paymentMethods ->
-                    Completable.fromAction { selectPaymentMethod(paymentMethods, fiatValue) }
-                  }
-            })
+    disposables.add(waitForOngoingPurchase(transaction.skuId).subscribeOn(networkThread)
+        .andThen(
+            inAppPurchaseInteractor.convertToLocalFiat(transactionValue)
+                .subscribeOn(networkThread)
+                .flatMapCompletable { fiatValue ->
+                  getPaymentMethods(fiatValue)
+                      .observeOn(viewScheduler)
+                      .flatMapCompletable { paymentMethods ->
+                        Completable.fromAction { selectPaymentMethod(paymentMethods, fiatValue) }
+                      }
+                })
         .subscribeOn(networkThread)
         .observeOn(viewScheduler)
         .subscribe({ }, { this.showError(it) }))
@@ -422,7 +424,8 @@ class PaymentMethodsPresenter(
   private fun updateBalanceDao() {
     disposables.add(
         Observable.zip(balanceInteract.getEthBalance(), balanceInteract.getCreditsBalance(),
-            balanceInteract.getAppcBalance(), Function3 { _: Any, _: Any, _: Any -> }).take(1)
+            balanceInteract.getAppcBalance(), Function3 { _: Any, _: Any, _: Any -> })
+            .take(1)
             .subscribeOn(networkThread)
             .subscribe())
   }
@@ -470,6 +473,10 @@ class PaymentMethodsPresenter(
     if (selectedPaymentMethod == paymentMethodsMapper.map(
             PaymentMethodsView.SelectedPaymentMethod.EARN_APPC)) {
       view.replaceBonus()
+    }
+    if (selectedPaymentMethod == paymentMethodsMapper.map(
+            PaymentMethodsView.SelectedPaymentMethod.MERGED_APPC)) {
+      view.hideBonus()
     } else {
       view.showBonus()
     }

--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/PaymentMethodsView.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/PaymentMethodsView.kt
@@ -42,6 +42,7 @@ interface PaymentMethodsView {
   fun lockRotation()
   fun showEarnAppcoins()
   fun showBonus()
+  fun hideBonus()
   fun replaceBonus()
   fun showWalletBlocked()
 


### PR DESCRIPTION
**What does this PR do?**

   This PR implements the logic needed to hide the bonus information in payment flow, when selecting APPC/APPC-C as the chosen payment method.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] PaymentMethodsFragment.kt
- [ ] PaymentMethodsView.kt
- [ ] PaymentMethodsPresenter.kt

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [MOB-456](https://aptoide.atlassian.net/browse/MOB-456)

**What are the relevant tickets?**

  Tickets related to this pull-request: [MOB-456](https://aptoide.atlassian.net/browse/MOB-456)


**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass