### PR TITLE
[MOB-398] - Fix bug when user goes to another app after pressing next…

### DIFF
--- a/app/src/main/java/com/asfoundation/wallet/wallet_validation/generic/PhoneValidationFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/wallet_validation/generic/PhoneValidationFragment.kt
@@ -75,6 +75,7 @@ class PhoneValidationFragment : DaggerFragment(),
   override fun onResume() {
     super.onResume()
 
+    presenter.onResume()
     focusAndShowKeyboard(phone_number)
   }
 

--- a/app/src/main/java/com/asfoundation/wallet/wallet_validation/generic/WalletValidationActivity.kt
+++ b/app/src/main/java/com/asfoundation/wallet/wallet_validation/generic/WalletValidationActivity.kt
@@ -116,11 +116,11 @@ class WalletValidationActivity : BaseActivity(),
   }
 
   override fun showCodeValidationView(countryCode: String, phoneNumber: String) {
-    increaseAnimationFrames()
     supportFragmentManager.beginTransaction()
         .replace(R.id.fragment_container,
             CodeValidationFragment.newInstance(countryCode, phoneNumber, hasBeenInvitedFlow))
         .commit()
+    increaseAnimationFrames()
   }
 
   override fun showCodeValidationView(validationInfo: ValidationInfo, errorMessage: Int) {

--- a/app/src/main/java/com/asfoundation/wallet/wallet_validation/poa/PoaPhoneValidationFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/wallet_validation/poa/PoaPhoneValidationFragment.kt
@@ -66,6 +66,7 @@ class PoaPhoneValidationFragment : DaggerFragment(),
   override fun onResume() {
     super.onResume()
 
+    presenter.onResume()
     focusAndShowKeyboard(phone_number)
   }
 


### PR DESCRIPTION
… button but before changing to second verification screen.

**What does this PR do?**

Fix bug when user presses next button on first wallet verification screen and presses the home button before the transition to the second screen occurs.
After coming back to the wallet the second verification screen should be shown, but wasn't before this PR.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] PhoneValidationPresenter.kt
- [ ] PhoneValidationFragment.kt
- [ ] PoaPhoneValidationPresenter.kt
- [ ] PoaPhoneValidationFragment.kt

**How should this be manually tested?**

1 - Open the wallet.
2 - Go to Verify Wallet screen.
3 - Insert a valid phone number
4 - Enable debugger
5 - add a breakpoint in SmsValidationInteract -> smsValidationRepository.requestValidationCode(phoneNumber)
6 - Press next button
7 - Press home button
8 - Resume debugger
9 - Go back to the app, second verification screen should be shown instead of first one.

**What are the relevant tickets?**

  Tickets related to this pull-request: [MOB-398](https://aptoide.atlassian.net/browse/MOB-398)
  Tickets related to this pull-request: [MOB-486](https://aptoide.atlassian.net/browse/MOB-486)

**Questions:**

   Does this add new dependencies which need to be added?
No

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass