### PR TITLE
[MOB-507] clicking in next enter doesnt navigate to next screen

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -20,6 +20,7 @@ repositories {
 }
 
 android {
+  buildToolsVersion '29.0.3'
   compileSdkVersion 29
   defaultConfig {
 

--- a/app/src/main/java/com/asfoundation/wallet/topup/TopUpFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/topup/TopUpFragment.kt
@@ -10,6 +10,7 @@ import android.view.ViewTreeObserver
 import android.view.animation.AccelerateDecelerateInterpolator
 import android.view.animation.Animation
 import android.view.animation.RotateAnimation
+import android.view.inputmethod.EditorInfo
 import android.view.inputmethod.InputMethodManager
 import android.widget.EditText
 import androidx.core.content.ContextCompat
@@ -173,6 +174,13 @@ class TopUpFragment : DaggerFragment(), TopUpFragmentView {
     main_value.setMinTextSize(
         resources.getDimensionPixelSize(R.dimen.topup_main_value_min_size)
             .toFloat())
+    main_value.setOnEditorActionListener { _, actionId, _ ->
+      if (EditorInfo.IME_ACTION_NEXT == actionId) {
+        hideKeyboard()
+        button.performClick()
+      }
+      true
+    }
     adapter = TopUpPaymentMethodAdapter(paymentMethods, paymentMethodClick)
 
     payment_methods.adapter = adapter

--- a/app/src/main/res/layout/fragment_top_up.xml
+++ b/app/src/main/res/layout/fragment_top_up.xml
@@ -45,7 +45,7 @@
           android:focusableInTouchMode="true"
           android:gravity="center"
           android:hint="0"
-          android:imeOptions="flagNoExtractUi|flagNoFullscreen"
+          android:imeOptions="flagNoExtractUi|flagNoFullscreen|actionNext"
           android:inputType="numberDecimal"
           android:maxWidth="152dp"
           android:maxLength="152"


### PR DESCRIPTION
**What does this PR do?**

   This PR changes the topup flow to handle keyboard function next as a button click

**Database changed?**

  No

**Where should the reviewer start?**

- [ ] TopUpFragment.kt

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [MOB-507](https://aptoide.atlassian.net/browse/MOB-507)

**What are the relevant tickets?**

  Tickets related to this pull-request: [MOB-507](https://aptoide.atlassian.net/browse/MOB-507)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new libs, new keys, etc.)




**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass