### PR TITLE
[MOB-515] Fix format error when showing send confirmation screen 

### DIFF
--- a/app/src/main/java/com/asfoundation/wallet/ui/ConfirmationActivity.java
+++ b/app/src/main/java/com/asfoundation/wallet/ui/ConfirmationActivity.java
@@ -21,6 +21,8 @@ import com.asfoundation.wallet.entity.ErrorEnvelope;
 import com.asfoundation.wallet.entity.PendingTransaction;
 import com.asfoundation.wallet.entity.TransactionBuilder;
 import com.asfoundation.wallet.util.BalanceUtils;
+import com.asfoundation.wallet.util.CurrencyFormatUtils;
+import com.asfoundation.wallet.util.WalletCurrency;
 import com.asfoundation.wallet.viewmodel.ConfirmationViewModel;
 import com.asfoundation.wallet.viewmodel.ConfirmationViewModelFactory;
 import com.asfoundation.wallet.viewmodel.GasSettingsViewModel;
@@ -37,6 +39,7 @@ public class ConfirmationActivity extends BaseActivity {
 
   AlertDialog dialog;
   @Inject ConfirmationViewModelFactory confirmationViewModelFactory;
+  CurrencyFormatUtils currencyFormatUtils;
   ConfirmationViewModel viewModel;
   private TextView fromAddressText;
   private TextView toAddressText;
@@ -52,7 +55,7 @@ public class ConfirmationActivity extends BaseActivity {
 
     setContentView(R.layout.activity_confirm);
     toolbar();
-
+    currencyFormatUtils = new CurrencyFormatUtils();
     fromAddressText = findViewById(R.id.text_from);
     toAddressText = findViewById(R.id.text_to);
     valueText = findViewById(R.id.text_value);
@@ -93,20 +96,24 @@ public class ConfirmationActivity extends BaseActivity {
     fromAddressText.setText(transactionBuilder.fromAddress());
     toAddressText.setText(transactionBuilder.toAddress());
 
-    String value = "-" + transactionBuilder.amount()
-        .toString();
+    String value = "-" + currencyFormatUtils.formatTransferCurrency(transactionBuilder.amount(),
+        WalletCurrency.ETHEREUM);
     String symbol = transactionBuilder.symbol();
     int smallTitleSize = (int) getResources().getDimension(R.dimen.small_text);
     int color = getResources().getColor(R.color.color_grey_9e);
     valueText.setText(BalanceUtils.formatBalance(value, symbol, smallTitleSize, color));
     BigDecimal gasPrice = transactionBuilder.gasSettings().gasPrice;
     BigDecimal gasLimit = transactionBuilder.gasSettings().gasLimit;
-    gasPriceText.setText(
-        getString(R.string.gas_price_value, BalanceUtils.weiToGwei(gasPrice), GWEI_UNIT));
+    String formattedGasPrice = getString(R.string.gas_price_value,
+        currencyFormatUtils.formatTransferCurrency(BalanceUtils.weiToGweiBigDecimal(gasPrice),
+            WalletCurrency.ETHEREUM), GWEI_UNIT);
+    gasPriceText.setText(formattedGasPrice);
     gasLimitText.setText(transactionBuilder.gasSettings().gasLimit.toPlainString());
 
-    String networkFee = BalanceUtils.weiToEth(gasPrice.multiply(gasLimit))
-        .toPlainString() + " " + C.ETH_SYMBOL;
+    String networkFee = currencyFormatUtils.formatTransferCurrency(
+        BalanceUtils.weiToEth(gasPrice.multiply(gasLimit)), WalletCurrency.ETHEREUM)
+        + " "
+        + C.ETH_SYMBOL;
     networkFeeText.setText(networkFee);
   }
 

--- a/app/src/main/java/com/asfoundation/wallet/ui/ConfirmationActivity.java
+++ b/app/src/main/java/com/asfoundation/wallet/ui/ConfirmationActivity.java
@@ -55,7 +55,7 @@ public class ConfirmationActivity extends BaseActivity {
 
     setContentView(R.layout.activity_confirm);
     toolbar();
-    currencyFormatUtils = new CurrencyFormatUtils();
+    currencyFormatUtils = CurrencyFormatUtils.Companion.create();
     fromAddressText = findViewById(R.id.text_from);
     toAddressText = findViewById(R.id.text_to);
     valueText = findViewById(R.id.text_value);

--- a/app/src/main/java/com/asfoundation/wallet/ui/ConfirmationActivity.java
+++ b/app/src/main/java/com/asfoundation/wallet/ui/ConfirmationActivity.java
@@ -105,7 +105,7 @@ public class ConfirmationActivity extends BaseActivity {
     BigDecimal gasPrice = transactionBuilder.gasSettings().gasPrice;
     BigDecimal gasLimit = transactionBuilder.gasSettings().gasLimit;
     String formattedGasPrice = getString(R.string.gas_price_value,
-        currencyFormatUtils.formatTransferCurrency(BalanceUtils.weiToGweiBigDecimal(gasPrice),
+        currencyFormatUtils.formatTransferCurrency(BalanceUtils.weiToGwei(gasPrice),
             WalletCurrency.ETHEREUM), GWEI_UNIT);
     gasPriceText.setText(formattedGasPrice);
     gasLimitText.setText(transactionBuilder.gasSettings().gasLimit.toPlainString());

--- a/app/src/main/java/com/asfoundation/wallet/ui/GasSettingsActivity.java
+++ b/app/src/main/java/com/asfoundation/wallet/ui/GasSettingsActivity.java
@@ -13,6 +13,8 @@ import com.asfoundation.wallet.C;
 import com.asfoundation.wallet.entity.GasSettings;
 import com.asfoundation.wallet.entity.NetworkInfo;
 import com.asfoundation.wallet.util.BalanceUtils;
+import com.asfoundation.wallet.util.CurrencyFormatUtils;
+import com.asfoundation.wallet.util.WalletCurrency;
 import com.asfoundation.wallet.viewmodel.GasSettingsViewModel;
 import com.asfoundation.wallet.viewmodel.GasSettingsViewModelFactory;
 import dagger.android.AndroidInjection;
@@ -24,7 +26,7 @@ public class GasSettingsActivity extends BaseActivity {
 
   @Inject GasSettingsViewModelFactory viewModelFactory;
   GasSettingsViewModel viewModel;
-
+  private CurrencyFormatUtils currencyFormatUtils;
   private TextView gasPriceText;
   private TextView gasLimitText;
   private TextView networkFeeText;
@@ -39,6 +41,7 @@ public class GasSettingsActivity extends BaseActivity {
     setContentView(R.layout.activity_gas_settings);
     toolbar();
 
+    currencyFormatUtils = new CurrencyFormatUtils();
     SeekBar gasPriceSlider = findViewById(R.id.gas_price_slider);
     SeekBar gasLimitSlider = findViewById(R.id.gas_limit_slider);
     gasPriceText = findViewById(R.id.gas_price_text);
@@ -143,8 +146,12 @@ public class GasSettingsActivity extends BaseActivity {
   }
 
   private void onGasPrice(BigInteger price) {
-    String priceStr = BalanceUtils.weiToGwei(new BigDecimal(price)) + " " + C.GWEI_UNIT;
-    gasPriceText.setText(priceStr);
+    BigDecimal priceStr = BalanceUtils.weiToGweiBigDecimal(new BigDecimal(price));
+    String formattedPrice =
+        currencyFormatUtils.formatTransferCurrency(priceStr, WalletCurrency.ETHEREUM)
+            + " "
+            + C.GWEI_UNIT;
+    gasPriceText.setText(formattedPrice);
 
     updateNetworkFee();
   }
@@ -156,9 +163,11 @@ public class GasSettingsActivity extends BaseActivity {
   }
 
   private void updateNetworkFee() {
-    String fee = BalanceUtils.weiToEth(viewModel.networkFee())
-        .toPlainString() + " " + C.ETH_SYMBOL;
-    networkFeeText.setText(fee);
+    BigDecimal fee = BalanceUtils.weiToEth(viewModel.networkFee());
+    String formattedFee = currencyFormatUtils.formatTransferCurrency(fee, WalletCurrency.ETHEREUM)
+        + " "
+        + C.ETH_SYMBOL;
+    networkFeeText.setText(formattedFee);
   }
 
   @Override public boolean onCreateOptionsMenu(Menu menu) {

--- a/app/src/main/java/com/asfoundation/wallet/ui/GasSettingsActivity.java
+++ b/app/src/main/java/com/asfoundation/wallet/ui/GasSettingsActivity.java
@@ -41,7 +41,7 @@ public class GasSettingsActivity extends BaseActivity {
     setContentView(R.layout.activity_gas_settings);
     toolbar();
 
-    currencyFormatUtils = new CurrencyFormatUtils();
+    currencyFormatUtils = CurrencyFormatUtils.Companion.create();
     SeekBar gasPriceSlider = findViewById(R.id.gas_price_slider);
     SeekBar gasLimitSlider = findViewById(R.id.gas_limit_slider);
     gasPriceText = findViewById(R.id.gas_price_text);

--- a/app/src/main/java/com/asfoundation/wallet/ui/GasSettingsActivity.java
+++ b/app/src/main/java/com/asfoundation/wallet/ui/GasSettingsActivity.java
@@ -146,7 +146,7 @@ public class GasSettingsActivity extends BaseActivity {
   }
 
   private void onGasPrice(BigInteger price) {
-    BigDecimal priceStr = BalanceUtils.weiToGweiBigDecimal(new BigDecimal(price));
+    BigDecimal priceStr = BalanceUtils.weiToGwei(new BigDecimal(price));
     String formattedPrice =
         currencyFormatUtils.formatTransferCurrency(priceStr, WalletCurrency.ETHEREUM)
             + " "

--- a/app/src/main/java/com/asfoundation/wallet/ui/transact/AppcoinsCreditsTransactSuccessPresenter.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/transact/AppcoinsCreditsTransactSuccessPresenter.kt
@@ -13,7 +13,7 @@ class AppcoinsCreditsTransactSuccessPresenter(private val view: AppcoinsCreditsT
                                               private val formatter: CurrencyFormatUtils) {
   fun present() {
     val walletCurrency = mapToWalletCurrency(currency)
-    val formattedAmount = formatter.formatTransferConfirmation(amount.toDouble(), walletCurrency)
+    val formattedAmount = formatter.formatTransferCurrency(amount, walletCurrency)
     view.setup(formattedAmount, walletCurrency.symbol, toAddress)
     handleOkButtonClick()
   }

--- a/app/src/main/java/com/asfoundation/wallet/util/BalanceUtils.java
+++ b/app/src/main/java/com/asfoundation/wallet/util/BalanceUtils.java
@@ -31,12 +31,7 @@ public class BalanceUtils {
     return Convert.fromWei(new BigDecimal(wei), Convert.Unit.GWEI);
   }
 
-  public static String weiToGwei(BigDecimal wei) {
-    return Convert.fromWei(wei, Convert.Unit.GWEI)
-        .toPlainString();
-  }
-
-  public static BigDecimal weiToGweiBigDecimal(BigDecimal wei) {
+  public static BigDecimal weiToGwei(BigDecimal wei) {
     return Convert.fromWei(wei, Convert.Unit.GWEI);
   }
 

--- a/app/src/main/java/com/asfoundation/wallet/util/BalanceUtils.java
+++ b/app/src/main/java/com/asfoundation/wallet/util/BalanceUtils.java
@@ -36,6 +36,10 @@ public class BalanceUtils {
         .toPlainString();
   }
 
+  public static BigDecimal weiToGweiBigDecimal(BigDecimal wei) {
+    return Convert.fromWei(wei, Convert.Unit.GWEI);
+  }
+
   public static BigInteger gweiToWei(BigDecimal gwei) {
     return Convert.toWei(gwei, Convert.Unit.GWEI)
         .toBigInteger();

--- a/app/src/main/java/com/asfoundation/wallet/util/CurrencyFormatUtils.kt
+++ b/app/src/main/java/com/asfoundation/wallet/util/CurrencyFormatUtils.kt
@@ -80,17 +80,18 @@ class CurrencyFormatUtils {
     return ethFormatter.format(value)
   }
 
-  fun formatTransferConfirmation(value: Double, currencyType: WalletCurrency): String {
+  fun formatTransferCurrency(value: BigDecimal, currencyType: WalletCurrency): String {
     val scale: Int = when (currencyType) {
       WalletCurrency.APPCOINS -> APPC_SCALE
       WalletCurrency.CREDITS -> CREDITS_SCALE
       WalletCurrency.ETHEREUM -> ETH_SCALE
       else -> throw IllegalArgumentException()
     }
-    val transferFormatter = NumberFormat.getNumberInstance()
+    val transferFormatter = DecimalFormat("#,##0.00")
         .apply {
           minimumFractionDigits = scale
           maximumFractionDigits = 15
+          isParseBigDecimal = true
           roundingMode = RoundingMode.FLOOR
         }
     return transferFormatter.format(value)

--- a/app/src/test/java/com/asfoundation/wallet/util/CurrencyFormatUtilsTest.kt
+++ b/app/src/test/java/com/asfoundation/wallet/util/CurrencyFormatUtilsTest.kt
@@ -127,11 +127,11 @@ class CurrencyFormatUtilsTest {
     //bigDecimalPlaces
     Locale.setDefault(Locale.US)
     formattedValueUs = formatter.formatTransferCurrency(bigDecimalValue, WalletCurrency.ETHEREUM)
-    expectedValueUs = "1.12345678901234"
+    expectedValueUs = "1.123456789012345"
 
     Locale.setDefault(Locale.FRANCE)
     formattedValueFr = formatter.formatTransferCurrency(bigDecimalValue, WalletCurrency.CREDITS)
-    expectedValueFr = "1,12345678901234"
+    expectedValueFr = "1,123456789012345"
 
     assertEquals(expectedValueUs, formattedValueUs)
     assertEquals(expectedValueFr, formattedValueFr)

--- a/app/src/test/java/com/asfoundation/wallet/util/CurrencyFormatUtilsTest.kt
+++ b/app/src/test/java/com/asfoundation/wallet/util/CurrencyFormatUtilsTest.kt
@@ -88,43 +88,75 @@ class CurrencyFormatUtilsTest {
   }
 
   @Test
-  fun formatTransferConfirmation() {
-    val bigValue = value
-    val smallValue = 1.123456789012345678
+  fun formatTransferCurrency() {
+    val bigValue = BigDecimal("123456789.0123")
+    val smallValue = BigDecimal("0.000001")
+    val bigDecimalValue = BigDecimal("1.12345678901234567")
+    val noDecimalPlaces = BigDecimal("1")
+    val oneDecimalPlaces = BigDecimal("0.4")
+    //Big value
     Locale.setDefault(Locale.US)
     var formattedValueUs =
-        formatter.formatTransferConfirmation(bigValue.toDouble(), WalletCurrency.ETHEREUM)
-    var expectedValueUs = "123,456,789.123456"
+        formatter.formatTransferCurrency(bigValue, WalletCurrency.ETHEREUM)
+    var expectedValueUs = "123,456,789.0123"
 
     Locale.setDefault(Locale.FRANCE)
     var formattedValueFr =
-        formatter.formatTransferConfirmation(bigValue.toDouble(), WalletCurrency.ETHEREUM)
-    var expectedValueFr = "123 456 789,123456"
+        formatter.formatTransferCurrency(bigValue, WalletCurrency.ETHEREUM)
+    var expectedValueFr = "123 456 789,0123"
 
     Locale.setDefault(Locale("pt", "BR"))
-    var formattedValueBr =
-        formatter.formatTransferConfirmation(bigValue.toDouble(), WalletCurrency.ETHEREUM)
-    var expectedValueBr = "123.456.789,123456"
+    val formattedValueBr =
+        formatter.formatTransferCurrency(bigValue, WalletCurrency.ETHEREUM)
+    val expectedValueBr = "123.456.789,0123"
 
     assertEquals(expectedValueUs, formattedValueUs)
     assertEquals(expectedValueFr, formattedValueFr)
     assertEquals(expectedValueBr, formattedValueBr)
-
+    //Small Value
     Locale.setDefault(Locale.US)
-    formattedValueUs = formatter.formatTransferConfirmation(smallValue, WalletCurrency.ETHEREUM)
-    expectedValueUs = "1.123456789012345"
+    formattedValueUs = formatter.formatTransferCurrency(smallValue, WalletCurrency.ETHEREUM)
+    expectedValueUs = "0.000001"
 
     Locale.setDefault(Locale.FRANCE)
-    formattedValueFr = formatter.formatTransferConfirmation(smallValue, WalletCurrency.ETHEREUM)
-    expectedValueFr = "1,123456789012345"
-
-    Locale.setDefault(Locale("pt", "BR"))
-    formattedValueBr = formatter.formatTransferConfirmation(smallValue, WalletCurrency.ETHEREUM)
-    expectedValueBr = "1,123456789012345"
+    formattedValueFr = formatter.formatTransferCurrency(smallValue, WalletCurrency.CREDITS)
+    expectedValueFr = "0,000001"
 
     assertEquals(expectedValueUs, formattedValueUs)
     assertEquals(expectedValueFr, formattedValueFr)
-    assertEquals(expectedValueBr, formattedValueBr)
+    //bigDecimalPlaces
+    Locale.setDefault(Locale.US)
+    formattedValueUs = formatter.formatTransferCurrency(bigDecimalValue, WalletCurrency.ETHEREUM)
+    expectedValueUs = "1.12345678901234"
+
+    Locale.setDefault(Locale.FRANCE)
+    formattedValueFr = formatter.formatTransferCurrency(bigDecimalValue, WalletCurrency.CREDITS)
+    expectedValueFr = "1,12345678901234"
+
+    assertEquals(expectedValueUs, formattedValueUs)
+    assertEquals(expectedValueFr, formattedValueFr)
+    //No Decimal Places
+    Locale.setDefault(Locale.US)
+    formattedValueUs = formatter.formatTransferCurrency(noDecimalPlaces, WalletCurrency.ETHEREUM)
+    expectedValueUs = "1.0000"
+
+    Locale.setDefault(Locale.FRANCE)
+    formattedValueFr = formatter.formatTransferCurrency(noDecimalPlaces, WalletCurrency.CREDITS)
+    expectedValueFr = "1,00"
+
+    assertEquals(expectedValueUs, formattedValueUs)
+    assertEquals(expectedValueFr, formattedValueFr)
+    //One decimal place
+    Locale.setDefault(Locale.US)
+    formattedValueUs = formatter.formatTransferCurrency(oneDecimalPlaces, WalletCurrency.ETHEREUM)
+    expectedValueUs = "0.4000"
+
+    Locale.setDefault(Locale.FRANCE)
+    formattedValueFr = formatter.formatTransferCurrency(oneDecimalPlaces, WalletCurrency.CREDITS)
+    expectedValueFr = "0,40"
+
+    assertEquals(expectedValueUs, formattedValueUs)
+    assertEquals(expectedValueFr, formattedValueFr)
   }
 
   @Test
@@ -167,7 +199,8 @@ class CurrencyFormatUtilsTest {
 
   @Test
   fun scaleFiat() {
-    val formattedValueUs = formatter.scaleFiat(value).toString()
+    val formattedValueUs = formatter.scaleFiat(value)
+        .toString()
     val expectedValueUs = "123456789.12"
 
     assertEquals(expectedValueUs, formattedValueUs)


### PR DESCRIPTION
**What does this PR do?**

Fixes a problem with the formatter on the sending screen. 
Also added the format to the ethereum confirmation and gas setting screen

**Database changed?**

No

**Where should the reviewer start?**

CurrencyFormatterUtils.kt

**How should this be manually tested?**

Send 1 APPC-C to another wallet and check if it shows 1,00 APPC
Try to send any value of ETH and check if the values display don't appear with extra decimal places

**What are the relevant tickets?**

https://aptoide.atlassian.net/browse/MOB-515

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new libs, new keys, etc.)




**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass