### PR TITLE
[MOB-550] - Default amount value is now 10.

### DIFF
--- a/app/src/main/java/com/asfoundation/wallet/topup/TopUpFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/topup/TopUpFragment.kt
@@ -160,12 +160,14 @@ class TopUpFragment : DaggerFragment(), TopUpFragmentView {
     outState.putSerializable(LOCAL_CURRENCY_PARAM, localCurrency)
   }
 
-  override fun setupUiElements(paymentMethods: List<PaymentMethodData>,
-                               localCurrency: LocalCurrency) {
+  override fun setupUiElements(
+      paymentMethods: List<PaymentMethodData>,
+      localCurrency: LocalCurrency,
+      defaultValue: String) {
     hideNoNetwork()
     if (isLocalCurrencyValid(localCurrency)) {
       this@TopUpFragment.localCurrency = localCurrency
-      setupCurrencyData(selectedCurrency, localCurrency.code, DEFAULT_VALUE,
+      setupCurrencyData(selectedCurrency, localCurrency.code, defaultValue,
           APPC_C_SYMBOL, DEFAULT_VALUE)
     }
     this@TopUpFragment.paymentMethods = paymentMethods

--- a/app/src/main/java/com/asfoundation/wallet/topup/TopUpFragmentPresenter.kt
+++ b/app/src/main/java/com/asfoundation/wallet/topup/TopUpFragmentPresenter.kt
@@ -17,6 +17,8 @@ import java.math.BigDecimal
 import java.util.concurrent.TimeUnit
 
 
+private val AMOUNT_DEFAULT_VALUE = "10"
+
 class TopUpFragmentPresenter(private val view: TopUpFragmentView,
                              private val activity: TopUpActivityView?,
                              private val interactor: TopUpInteractor,
@@ -60,7 +62,8 @@ class TopUpFragmentPresenter(private val view: TopUpFragmentView,
             .observeOn(viewScheduler),
         BiFunction { paymentMethods: List<PaymentMethodData>, values: TopUpLimitValues ->
           view.setupUiElements(filterPaymentMethods(paymentMethods),
-              LocalCurrency(values.maxValue.symbol, values.maxValue.currency))
+              LocalCurrency(values.maxValue.symbol, values.maxValue.currency),
+              AMOUNT_DEFAULT_VALUE)
         })
         .subscribe({}, { handleError(it) }))
   }

--- a/app/src/main/java/com/asfoundation/wallet/topup/TopUpFragmentPresenter.kt
+++ b/app/src/main/java/com/asfoundation/wallet/topup/TopUpFragmentPresenter.kt
@@ -17,8 +17,6 @@ import java.math.BigDecimal
 import java.util.concurrent.TimeUnit
 
 
-private val AMOUNT_DEFAULT_VALUE = "10"
-
 class TopUpFragmentPresenter(private val view: TopUpFragmentView,
                              private val activity: TopUpActivityView?,
                              private val interactor: TopUpInteractor,
@@ -33,6 +31,7 @@ class TopUpFragmentPresenter(private val view: TopUpFragmentView,
 
   companion object {
     private const val NUMERIC_REGEX = "^([1-9]|[0-9]+[,.]+[0-9])[0-9]*?\$"
+    private const val AMOUNT_DEFAULT_VALUE = "10"
   }
 
   fun present(appPackage: String) {

--- a/app/src/main/java/com/asfoundation/wallet/topup/TopUpFragmentView.kt
+++ b/app/src/main/java/com/asfoundation/wallet/topup/TopUpFragmentView.kt
@@ -11,7 +11,8 @@ interface TopUpFragmentView {
   fun getEditTextChanges(): Observable<TopUpData>
   fun getPaymentMethodClick(): Observable<String>
   fun getNextClick(): Observable<TopUpData>
-  fun setupUiElements(paymentMethods: List<PaymentMethodData>, localCurrency: LocalCurrency)
+  fun setupUiElements(paymentMethods: List<PaymentMethodData>, localCurrency: LocalCurrency,
+                      defaultValue: String)
   fun setConversionValue(topUpData: TopUpData)
   fun switchCurrencyData()
   fun setNextButtonState(enabled: Boolean)


### PR DESCRIPTION
**What does this PR do?**

This PR changes the default amount value to 10.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] TopUpFragmentPresenter.kt

**How should this be manually tested?**

Enter top-up screen, the default value should now be 10.

**What are the relevant tickets?**

  Tickets related to this pull-request: [MOB-550](https://aptoide.atlassian.net/browse/MOB-550)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new libs, new keys, etc.)

No


**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass