### PR TITLE
[MOB-554] Change default value in topup to use 2 value from default values

### DIFF
--- a/app/src/main/java/com/asfoundation/wallet/topup/TopUpFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/topup/TopUpFragment.kt
@@ -160,15 +160,13 @@ class TopUpFragment : DaggerFragment(), TopUpFragmentView {
     outState.putSerializable(LOCAL_CURRENCY_PARAM, localCurrency)
   }
 
-  override fun setupUiElements(
-      paymentMethods: List<PaymentMethodData>,
-      localCurrency: LocalCurrency,
-      defaultValue: String) {
+  override fun setupUiElements(paymentMethods: List<PaymentMethodData>,
+                               localCurrency: LocalCurrency) {
     hideNoNetwork()
     if (isLocalCurrencyValid(localCurrency)) {
       this@TopUpFragment.localCurrency = localCurrency
-      setupCurrencyData(selectedCurrency, localCurrency.code, defaultValue,
-          APPC_C_SYMBOL, DEFAULT_VALUE)
+      setupCurrencyData(selectedCurrency, localCurrency.code, DEFAULT_VALUE, APPC_C_SYMBOL,
+          DEFAULT_VALUE)
     }
     this@TopUpFragment.paymentMethods = paymentMethods
     main_value.isEnabled = true
@@ -199,6 +197,10 @@ class TopUpFragment : DaggerFragment(), TopUpFragmentView {
       val imm = context?.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager?
       imm?.showSoftInput(view, InputMethodManager.SHOW_FORCED)
     }
+  }
+
+  override fun setDefaultValue(amount: String) {
+    setupCurrencyData(selectedCurrency, localCurrency.code, amount, APPC_C_SYMBOL, DEFAULT_VALUE)
   }
 
   override fun setValuesAdapter(values: List<FiatValue>) {

--- a/app/src/main/java/com/asfoundation/wallet/topup/TopUpFragmentPresenter.kt
+++ b/app/src/main/java/com/asfoundation/wallet/topup/TopUpFragmentPresenter.kt
@@ -61,8 +61,7 @@ class TopUpFragmentPresenter(private val view: TopUpFragmentView,
             .observeOn(viewScheduler),
         BiFunction { paymentMethods: List<PaymentMethodData>, values: TopUpLimitValues ->
           view.setupUiElements(filterPaymentMethods(paymentMethods),
-              LocalCurrency(values.maxValue.symbol, values.maxValue.currency),
-              AMOUNT_DEFAULT_VALUE)
+              LocalCurrency(values.maxValue.symbol, values.maxValue.currency))
         })
         .subscribe({}, { handleError(it) }))
   }
@@ -76,11 +75,18 @@ class TopUpFragmentPresenter(private val view: TopUpFragmentView,
             view.hideValuesAdapter()
             false
           } else {
-            view.setValuesAdapter(it.values)
+            updateDefaultValues(it.values)
             true
           }
         }
         .subscribe())
+  }
+
+  private fun updateDefaultValues(values: List<FiatValue>) {
+    val defaultFiatValue = values.drop(1)
+        .first()
+    view.setDefaultValue(defaultFiatValue.amount.toString())
+    view.setValuesAdapter(values)
   }
 
   private fun handleKeyboardEvents() {

--- a/app/src/main/java/com/asfoundation/wallet/topup/TopUpFragmentView.kt
+++ b/app/src/main/java/com/asfoundation/wallet/topup/TopUpFragmentView.kt
@@ -11,8 +11,7 @@ interface TopUpFragmentView {
   fun getEditTextChanges(): Observable<TopUpData>
   fun getPaymentMethodClick(): Observable<String>
   fun getNextClick(): Observable<TopUpData>
-  fun setupUiElements(paymentMethods: List<PaymentMethodData>, localCurrency: LocalCurrency,
-                      defaultValue: String)
+  fun setupUiElements(paymentMethods: List<PaymentMethodData>, localCurrency: LocalCurrency)
   fun setConversionValue(topUpData: TopUpData)
   fun switchCurrencyData()
   fun setNextButtonState(enabled: Boolean)
@@ -43,4 +42,5 @@ interface TopUpFragmentView {
   fun showValuesAdapter()
   fun hideValuesAdapter()
   fun getKeyboardEvents(): Observable<Boolean>
+  fun setDefaultValue(amount: String)
 }


### PR DESCRIPTION
**What does this PR do?**

   This PR Changes default value in topup to use 2 value from default values

**Database changed?**

  No

**Where should the reviewer start?**

- [ ] TopUpFragment.kt
- [ ] TopUpFragmentPresenter.kt
- [ ] TopUpFragmentView.kt

**How should this be manually tested?**
Open topup and check if the default value is equal to the second default value

  Flow on how to test this or QA Tickets related to this use-case: [MOB-554](https://aptoide.atlassian.net/browse/MOB-554)

**What are the relevant tickets?**

  Tickets related to this pull-request: [MOB-554](https://aptoide.atlassian.net/browse/MOB-554)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new libs, new keys, etc.)




**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass