### PR TITLE
[MOB-487] Fixed sms request code called in main thread. Fixed retry button not resending the request

### DIFF
--- a/app/src/main/java/com/asfoundation/wallet/wallet_validation/poa/PoaWalletValidationActivity.kt
+++ b/app/src/main/java/com/asfoundation/wallet/wallet_validation/poa/PoaWalletValidationActivity.kt
@@ -23,10 +23,13 @@ class PoaWalletValidationActivity : BaseActivity(),
     PoaWalletValidationView {
 
   private lateinit var presenter: PoaWalletValidationPresenter
+
   @Inject
   lateinit var smsValidationRepository: SmsValidationRepositoryType
+
   @Inject
   lateinit var walletInteractor: FindDefaultWalletInteract
+
   @Inject
   lateinit var createWalletInteractor: CreateWalletInteract
   private var walletValidated: Boolean = false
@@ -121,8 +124,7 @@ class PoaWalletValidationActivity : BaseActivity(),
 
   override fun closeCancel(removeTask: Boolean) {
     val intent = Intent()
-    setResult(
-        RESULT_CANCELED, intent)
+    setResult(RESULT_CANCELED, intent)
     if (removeTask) {
       finishAndRemoveTask()
     } else {


### PR DESCRIPTION

**What does this PR do?**

   This PR fixes an issues causing the retry button in phone validation not to resending the request validation code. Also, it fixes a network request being called in the main thread

**Database changed?**

  No

**Where should the reviewer start?**

- [ ] PhoneValidationPresenter.kt
- [ ] PoaWalletValidationActivity.kt

**How should this be manually tested?**
Start the wallet validation flow with no internet, attempt to send a phone number to get the code, then tap retry on the next screen.
  Flow on how to test this or QA Tickets related to this use-case: [MOB-487](https://aptoide.atlassian.net/browse/MOB-487)

**What are the relevant tickets?**

  Tickets related to this pull-request: [MOB-487](https://aptoide.atlassian.net/browse/MOB-487)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new libs, new keys, etc.)




**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass