### PR TITLE
[MOB-576] Fixed phone no internet screen listening in the wrong button for lalter clicks

### DIFF
--- a/app/src/main/java/com/asfoundation/wallet/wallet_validation/generic/PhoneValidationFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/wallet_validation/generic/PhoneValidationFragment.kt
@@ -117,7 +117,7 @@ class PhoneValidationFragment : DaggerFragment(),
   }
 
   override fun getLaterButtonClicks(): Observable<PhoneValidationClickData> {
-    return RxView.clicks(cancel_button)
+    return RxView.clicks(later_button)
         .map { PhoneValidationClickData("", "", previousContext) }
   }
 


### PR DESCRIPTION

**What does this PR do?**
This PR fixes the later button in the wallet phone validation screen that is not doing anything when there is no internet connection

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] PhoneValidationFragment.kt

**How should this be manually tested?**
Start the wallet validation flow with no internet, insert a valid phone number to get the code and tap next.
  Flow on how to test this or QA Tickets related to this use-case: [MOB-576](https://aptoide.atlassian.net/browse/MOB-576)

**What are the relevant tickets?**

  Tickets related to this pull-request: [MOB-576](https://aptoide.atlassian.net/browse/MOB-576)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new libs, new keys, etc.)




**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass