### PR TITLE
[MOB-577] Fized topup not reloading info after recovering from no network

### DIFF
--- a/app/src/main/java/com/asfoundation/wallet/topup/TopUpFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/topup/TopUpFragment.kt
@@ -162,12 +162,9 @@ class TopUpFragment : DaggerFragment(), TopUpFragmentView {
   override fun onSaveInstanceState(outState: Bundle) {
     super.onSaveInstanceState(outState)
     outState.putString(SELECTED_VALUE_PARAM, main_value.text.toString())
-    val selectedItem = if (::adapter.isInitialized) {
-      adapter.getSelectedItem()
-    } else {
-      0
+    if (::adapter.isInitialized) {
+      outState.putInt(SELECTED_PAYMENT_METHOD_PARAM, adapter.getSelectedItem())
     }
-    outState.putInt(SELECTED_PAYMENT_METHOD_PARAM, selectedItem)
     outState.putString(SELECTED_CURRENCY_PARAM, selectedCurrency)
     outState.putSerializable(LOCAL_CURRENCY_PARAM, localCurrency)
   }

--- a/app/src/main/java/com/asfoundation/wallet/topup/TopUpFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/topup/TopUpFragment.kt
@@ -207,7 +207,7 @@ class TopUpFragment : DaggerFragment(), TopUpFragmentView {
     }
   }
 
-  override fun setAmountValue(amount: String) {
+  override fun setDefaultAmountValue(amount: String) {
     setupCurrencyData(selectedCurrency, localCurrency.code, amount, APPC_C_SYMBOL, DEFAULT_VALUE)
   }
 
@@ -425,6 +425,7 @@ class TopUpFragment : DaggerFragment(), TopUpFragmentView {
   }
 
   override fun showNoNetworkError() {
+    hideKeyboard()
     no_network.visibility = View.VISIBLE
     retry_button.visibility = View.VISIBLE
     retry_animation.visibility = View.GONE

--- a/app/src/main/java/com/asfoundation/wallet/topup/TopUpFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/topup/TopUpFragment.kt
@@ -162,7 +162,12 @@ class TopUpFragment : DaggerFragment(), TopUpFragmentView {
   override fun onSaveInstanceState(outState: Bundle) {
     super.onSaveInstanceState(outState)
     outState.putString(SELECTED_VALUE_PARAM, main_value.text.toString())
-    outState.putInt(SELECTED_PAYMENT_METHOD_PARAM, adapter.getSelectedItem())
+    val selectedItem = if (::adapter.isInitialized) {
+      adapter.getSelectedItem()
+    } else {
+      0
+    }
+    outState.putInt(SELECTED_PAYMENT_METHOD_PARAM, selectedItem)
     outState.putString(SELECTED_CURRENCY_PARAM, selectedCurrency)
     outState.putSerializable(LOCAL_CURRENCY_PARAM, localCurrency)
   }

--- a/app/src/main/java/com/asfoundation/wallet/topup/TopUpFragmentPresenter.kt
+++ b/app/src/main/java/com/asfoundation/wallet/topup/TopUpFragmentPresenter.kt
@@ -12,7 +12,7 @@ import io.reactivex.Observable
 import io.reactivex.Scheduler
 import io.reactivex.Single
 import io.reactivex.disposables.CompositeDisposable
-import io.reactivex.functions.BiFunction
+import io.reactivex.functions.Function3
 import java.math.BigDecimal
 import java.util.concurrent.TimeUnit
 
@@ -42,7 +42,6 @@ class TopUpFragmentPresenter(private val view: TopUpFragmentView,
     handleManualAmountChange(appPackage)
     handlePaymentMethodSelected()
     handleValuesClicks()
-    handleValues()
     handleKeyboardEvents()
   }
 
@@ -59,34 +58,28 @@ class TopUpFragmentPresenter(private val view: TopUpFragmentView,
         interactor.getLimitTopUpValues()
             .subscribeOn(networkScheduler)
             .observeOn(viewScheduler),
-        BiFunction { paymentMethods: List<PaymentMethodData>, values: TopUpLimitValues ->
+        interactor.getDefaultValues()
+            .subscribeOn(networkScheduler)
+            .observeOn(viewScheduler),
+        Function3 { paymentMethods: List<PaymentMethodData>, values: TopUpLimitValues, defaultValues: TopUpValuesModel ->
           view.setupUiElements(filterPaymentMethods(paymentMethods),
               LocalCurrency(values.maxValue.symbol, values.maxValue.currency))
+          updateDefaultValues(defaultValues)
         })
         .subscribe({}, { handleError(it) }))
   }
 
-  private fun handleValues() {
-    disposables.add(interactor.getDefaultValues()
-        .subscribeOn(networkScheduler)
-        .observeOn(viewScheduler)
-        .doOnSuccess {
-          hasDefaultValues = if (it.error.hasError || it.values.size < 3) {
-            view.hideValuesAdapter()
-            false
-          } else {
-            updateDefaultValues(it.values)
-            true
-          }
-        }
-        .subscribe())
-  }
-
-  private fun updateDefaultValues(values: List<FiatValue>) {
-    val defaultFiatValue = values.drop(1)
-        .first()
-    view.setAmountValue(selectedValue ?: defaultFiatValue.amount.toString())
-    view.setValuesAdapter(values)
+  private fun updateDefaultValues(topUpValuesModel: TopUpValuesModel) {
+    hasDefaultValues = topUpValuesModel.error.hasError.not() && topUpValuesModel.values.size >= 3
+    if (hasDefaultValues) {
+      val defaultValues = topUpValuesModel.values
+      val defaultFiatValue = defaultValues.drop(1)
+          .first()
+      view.setDefaultAmountValue(selectedValue ?: defaultFiatValue.amount.toString())
+      view.setValuesAdapter(defaultValues)
+    } else {
+      view.hideValuesAdapter()
+    }
   }
 
   private fun handleKeyboardEvents() {

--- a/app/src/main/java/com/asfoundation/wallet/topup/TopUpFragmentView.kt
+++ b/app/src/main/java/com/asfoundation/wallet/topup/TopUpFragmentView.kt
@@ -42,5 +42,5 @@ interface TopUpFragmentView {
   fun showValuesAdapter()
   fun hideValuesAdapter()
   fun getKeyboardEvents(): Observable<Boolean>
-  fun setAmountValue(amount: String)
+  fun setDefaultAmountValue(amount: String)
 }

--- a/app/src/main/java/com/asfoundation/wallet/topup/payment/AdyenTopUpFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/topup/payment/AdyenTopUpFragment.kt
@@ -395,10 +395,13 @@ class AdyenTopUpFragment : DaggerFragment(), AdyenTopUpView {
   private fun setupUi() {
     credit_card_info_container.visibility = INVISIBLE
     button.isEnabled = false
-    button.setText(R.string.topup_home_button)
-    setupAdyenLayouts()
 
-    if (paymentType == PaymentType.CARD.name) setupCardConfiguration()
+    if (paymentType == PaymentType.CARD.name) {
+      button.setText(R.string.topup_home_button)
+
+      setupAdyenLayouts()
+      setupCardConfiguration()
+    }
 
     setupDialogs()
     topUpView.showToolbar()

--- a/app/src/main/java/com/asfoundation/wallet/topup/payment/AdyenTopUpPresenter.kt
+++ b/app/src/main/java/com/asfoundation/wallet/topup/payment/AdyenTopUpPresenter.kt
@@ -108,7 +108,7 @@ class AdyenTopUpPresenter(private val view: AdyenTopUpView,
             }
           }
         }
-        .subscribe())
+        .subscribe({}, { it.printStackTrace() }))
   }
 
   private fun launchPaypal(paymentMethodInfo: PaymentMethod, priceAmount: BigDecimal,


### PR DESCRIPTION

**What does this PR do?**

  This pr fixes a bug where the pre selected amount in the edit text and the default values weren't reloaded if the user started the topup without internet.

   Explain any technical decisions that were made and why (when it makes sense).

**Database changed?**

   Yes | No

**Where should the reviewer start?**

- [ ] TopUpFragment.kt
- [ ] TopUpFragmentPresenter.kt
- [ ] TopUpFragmentView.kt

**How should this be manually tested?**
Start the topup without internet. Turn internet on and click retry
  Flow on how to test this or QA Tickets related to this use-case: [MOB-577](https://aptoide.atlassian.net/browse/MOB-577)

**What are the relevant tickets?**

  Tickets related to this pull-request: [MOB-577](https://aptoide.atlassian.net/browse/MOB-577)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new libs, new keys, etc.)




**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass