### PR TITLE
[MOB-584] Fixed keyboard left open after leaving topup.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -105,7 +105,7 @@ android {
     }
     debug {
       minifyEnabled false
-      ext.alwaysUpdateBuildId = false
+      ext.enableCrashlytics = false
       proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
       applicationIdSuffix ".dev"
       versionNameSuffix ".dev"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -105,6 +105,7 @@ android {
     }
     debug {
       minifyEnabled false
+      ext.alwaysUpdateBuildId = false
       proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
       applicationIdSuffix ".dev"
       versionNameSuffix ".dev"

--- a/app/src/main/java/com/asfoundation/wallet/topup/TopUpFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/topup/TopUpFragment.kt
@@ -159,6 +159,11 @@ class TopUpFragment : DaggerFragment(), TopUpFragmentView {
     view.viewTreeObserver.addOnGlobalLayoutListener(listener)
   }
 
+  override fun onResume() {
+    focusAndShowKeyboard(main_value)
+    super.onResume()
+  }
+
   override fun onSaveInstanceState(outState: Bundle) {
     super.onSaveInstanceState(outState)
     outState.putString(SELECTED_VALUE_PARAM, main_value.text.toString())
@@ -179,7 +184,6 @@ class TopUpFragment : DaggerFragment(), TopUpFragmentView {
     }
     this@TopUpFragment.paymentMethods = paymentMethods
     main_value.isEnabled = true
-    focusAndShowKeyboard(main_value)
     main_value.setMinTextSize(
         resources.getDimensionPixelSize(R.dimen.topup_main_value_min_size)
             .toFloat())
@@ -238,6 +242,11 @@ class TopUpFragment : DaggerFragment(), TopUpFragmentView {
 
   override fun getKeyboardEvents(): Observable<Boolean> {
     return keyboardEvents
+  }
+
+  override fun onPause() {
+    hideKeyboard()
+    super.onPause()
   }
 
   override fun onDestroy() {


### PR DESCRIPTION
**What does this PR do?**

   This PR fixes the keyboard in topup being left open after leaving the fragment.
   Also, it was added a flag to the build config in order to disable crashlytics in debug mode and with that enable applyc changes feature ([Here](https://developer.android.com/studio/build/optimize-your-build?utm_source=android-studio#disable-crashlytics-build-id))

   Explain any technical decisions that were made and why (when it makes sense).


**Database changed?**

   No

**Where should the reviewer start?**

- [ ] TopUpFragment.kt
- [ ] build.gradle

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [MOB-584](https://aptoide.atlassian.net/browse/MOB-584)

**What are the relevant tickets?**

  Tickets related to this pull-request: [MOB-584](https://aptoide.atlassian.net/browse/MOB-584)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new libs, new keys, etc.)




**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass