### PR TITLE
[MOB-605] improve logic to show async payment final dialog

### DIFF
--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/LocalPaymentFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/LocalPaymentFragment.kt
@@ -16,7 +16,6 @@ import com.asfoundation.wallet.ui.iab.LocalPaymentView.ViewState
 import com.asfoundation.wallet.ui.iab.LocalPaymentView.ViewState.*
 import com.jakewharton.rxbinding2.view.RxView
 import dagger.android.support.DaggerFragment
-import io.reactivex.Observable
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.schedulers.Schedulers
@@ -48,7 +47,6 @@ class LocalPaymentFragment : DaggerFragment(), LocalPaymentView {
     private const val PAYLOAD = "PAYLOAD"
     private const val PAYMENT_METHOD_URL = "payment_method_url"
     private const val PAYMENT_METHOD_LABEL = "payment_method_label"
-
     private const val ANIMATION_STEP_ONE_START_FRAME = 0
     private const val ANIMATION_STEP_TWO_START_FRAME = 80
     private const val MID_ANIMATION_FRAME_INCREMENT = 40
@@ -62,24 +60,24 @@ class LocalPaymentFragment : DaggerFragment(), LocalPaymentView {
                     type: String, amount: BigDecimal, callbackUrl: String?, orderReference: String?,
                     payload: String?, paymentMethodIconUrl: String,
                     paymentMethodLabel: String): LocalPaymentFragment {
-      val fragment = LocalPaymentFragment()
-      fragment.arguments = Bundle().apply {
-        putString(DOMAIN_KEY, domain)
-        putString(SKU_ID_KEY, skudId)
-        putString(ORIGINAL_AMOUNT_KEY, originalAmount)
-        putString(CURRENCY_KEY, currency)
-        putString(BONUS_KEY, bonus)
-        putString(PAYMENT_KEY, selectedPaymentMethod)
-        putString(DEV_ADDRESS_KEY, developerAddress)
-        putString(TYPE_KEY, type)
-        putSerializable(AMOUNT_KEY, amount)
-        putString(CALLBACK_URL, callbackUrl)
-        putString(ORDER_REFERENCE, orderReference)
-        putString(PAYLOAD, payload)
-        putString(PAYMENT_METHOD_URL, paymentMethodIconUrl)
-        putString(PAYMENT_METHOD_LABEL, paymentMethodLabel)
+      return LocalPaymentFragment().apply {
+        arguments = Bundle().apply {
+          putString(DOMAIN_KEY, domain)
+          putString(SKU_ID_KEY, skudId)
+          putString(ORIGINAL_AMOUNT_KEY, originalAmount)
+          putString(CURRENCY_KEY, currency)
+          putString(BONUS_KEY, bonus)
+          putString(PAYMENT_KEY, selectedPaymentMethod)
+          putString(DEV_ADDRESS_KEY, developerAddress)
+          putString(TYPE_KEY, type)
+          putSerializable(AMOUNT_KEY, amount)
+          putString(CALLBACK_URL, callbackUrl)
+          putString(ORDER_REFERENCE, orderReference)
+          putString(PAYLOAD, payload)
+          putString(PAYMENT_METHOD_URL, paymentMethodIconUrl)
+          putString(PAYMENT_METHOD_LABEL, paymentMethodLabel)
+        }
       }
-      return fragment
     }
   }
 
@@ -195,8 +193,10 @@ class LocalPaymentFragment : DaggerFragment(), LocalPaymentView {
 
   @Inject
   lateinit var localPaymentInteractor: LocalPaymentInteractor
+
   @Inject
   lateinit var analytics: LocalPaymentAnalytics
+
   private lateinit var iabView: IabView
   private lateinit var navigator: FragmentNavigator
   private lateinit var localPaymentPresenter: LocalPaymentPresenter
@@ -225,7 +225,7 @@ class LocalPaymentFragment : DaggerFragment(), LocalPaymentView {
 
   override fun onAttach(context: Context) {
     super.onAttach(context)
-    if (context !is IabView) {
+    check(context is IabView) {
       throw IllegalStateException("Local payment fragment must be attached to IAB activity")
     }
     iabView = context
@@ -259,14 +259,12 @@ class LocalPaymentFragment : DaggerFragment(), LocalPaymentView {
     super.onViewStateRestored(savedInstanceState)
   }
 
-  private fun setViewState(viewState: ViewState?) {
-    when (viewState) {
-      COMPLETED -> showCompletedPayment()
-      PENDING_USER_PAYMENT -> localPaymentPresenter.preparePendingUserPayment()
-      ERROR -> showError()
-      LOADING -> showProcessingLoading()
-      else -> {
-      }
+  private fun setViewState(viewState: ViewState?) = when (viewState) {
+    COMPLETED -> showCompletedPayment()
+    PENDING_USER_PAYMENT -> localPaymentPresenter.preparePendingUserPayment()
+    ERROR -> showError()
+    LOADING -> showProcessingLoading()
+    else -> {
     }
   }
 
@@ -294,9 +292,7 @@ class LocalPaymentFragment : DaggerFragment(), LocalPaymentView {
     return inflater.inflate(R.layout.local_payment_layout, container, false)
   }
 
-  override fun getOkErrorClick(): Observable<Any> {
-    return RxView.clicks(error_view.activity_iab_error_ok_button)
-  }
+  override fun getOkErrorClick() = RxView.clicks(error_view.activity_iab_error_ok_button)
 
   override fun getGotItClick() = RxView.clicks(got_it_button)
 
@@ -379,9 +375,7 @@ class LocalPaymentFragment : DaggerFragment(), LocalPaymentView {
     iabView.close(Bundle())
   }
 
-  override fun getAnimationDuration(): Long {
-    return complete_payment_view.lottie_transaction_success.duration
-  }
+  override fun getAnimationDuration() = complete_payment_view.lottie_transaction_success.duration
 
   override fun popView(bundle: Bundle) {
     bundle.putString(InAppPurchaseInteractor.PRE_SELECTED_PAYMENT_METHOD_KEY,
@@ -397,8 +391,7 @@ class LocalPaymentFragment : DaggerFragment(), LocalPaymentView {
     pending_user_payment_view?.in_progress_animation?.setMinAndMaxFrame(minFrame, maxFrame)
     pending_user_payment_view?.in_progress_animation?.addAnimatorListener(object :
         Animator.AnimatorListener {
-      override fun onAnimationRepeat(animation: Animator?) {
-      }
+      override fun onAnimationRepeat(animation: Animator?) = Unit
 
       override fun onAnimationEnd(animation: Animator?) {
         if (maxFrame == LAST_ANIMATION_FRAME) {
@@ -417,8 +410,7 @@ class LocalPaymentFragment : DaggerFragment(), LocalPaymentView {
         }
       }
 
-      override fun onAnimationCancel(animation: Animator?) {
-      }
+      override fun onAnimationCancel(animation: Animator?) = Unit
 
       override fun onAnimationStart(animation: Animator?) {
         when (minFrame) {

--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/LocalPaymentFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/LocalPaymentFragment.kt
@@ -53,7 +53,6 @@ class LocalPaymentFragment : DaggerFragment(), LocalPaymentView {
     private const val LAST_ANIMATION_FRAME_INCREMENT = 30
     private const val BUTTON_ANIMATION_START_FRAME = 120
     private const val LAST_ANIMATION_FRAME = 150
-    private val ASYNC_PAYMENTS_ID = listOf("oxxo", "boleto", "bank_transfer", "alfamart")
 
     @JvmStatic
     fun newInstance(domain: String, skudId: String?, originalAmount: String?, currency: String?,
@@ -214,7 +213,7 @@ class LocalPaymentFragment : DaggerFragment(), LocalPaymentView {
             paymentId, developerAddress, localPaymentInteractor, navigator, type, amount, analytics,
             savedInstanceState, AndroidSchedulers.mainThread(), Schedulers.io(),
             CompositeDisposable(), callbackUrl, orderReference, payload, context,
-            paymentMethodIconUrl, isAsync())
+            paymentMethodIconUrl)
   }
 
 
@@ -459,7 +458,5 @@ class LocalPaymentFragment : DaggerFragment(), LocalPaymentView {
           .setListener(null)
     }
   }
-
-  private fun isAsync() = ASYNC_PAYMENTS_ID.contains(paymentId)
 
 }

--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/LocalPaymentFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/LocalPaymentFragment.kt
@@ -53,6 +53,7 @@ class LocalPaymentFragment : DaggerFragment(), LocalPaymentView {
     private const val LAST_ANIMATION_FRAME_INCREMENT = 30
     private const val BUTTON_ANIMATION_START_FRAME = 120
     private const val LAST_ANIMATION_FRAME = 150
+    private val ASYNC_PAYMENTS_ID = listOf("oxxo", "boleto", "bank_transfer", "alfamart")
 
     @JvmStatic
     fun newInstance(domain: String, skudId: String?, originalAmount: String?, currency: String?,
@@ -213,7 +214,7 @@ class LocalPaymentFragment : DaggerFragment(), LocalPaymentView {
             paymentId, developerAddress, localPaymentInteractor, navigator, type, amount, analytics,
             savedInstanceState, AndroidSchedulers.mainThread(), Schedulers.io(),
             CompositeDisposable(), callbackUrl, orderReference, payload, context,
-            paymentMethodIconUrl)
+            paymentMethodIconUrl, isAsync())
   }
 
 
@@ -458,5 +459,7 @@ class LocalPaymentFragment : DaggerFragment(), LocalPaymentView {
           .setListener(null)
     }
   }
+
+  private fun isAsync() = ASYNC_PAYMENTS_ID.contains(paymentId)
 
 }

--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/LocalPaymentInteractor.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/LocalPaymentInteractor.kt
@@ -44,30 +44,29 @@ class LocalPaymentInteractor(private val deepLinkRepository: InAppDeepLinkReposi
         }
   }
 
-  fun getTransaction(uri: Uri): Observable<Transaction> {
-    return inAppPurchaseInteractor.getTransaction(uri.lastPathSegment)
-        .filter { isEndingState(it.status, it.type) }
-        .distinctUntilChanged { transaction -> transaction.status }
-  }
+  fun getTransaction(uri: Uri): Observable<Transaction> =
+      inAppPurchaseInteractor.getTransaction(uri.lastPathSegment)
+          .filter { isEndingState(it.status, it.type) }
+          .distinctUntilChanged { transaction -> transaction.status }
 
-  private fun isEndingState(status: Transaction.Status, type: String): Boolean {
-    return (status == PENDING_USER_PAYMENT && type == "TOPUP") || (status == COMPLETED && (type == "INAPP" || type == "INAPP_UNMANAGED")) || status == FAILED || status == CANCELED || status == INVALID_TRANSACTION
-  }
+  private fun isEndingState(status: Transaction.Status, type: String) =
+      (status == PENDING_USER_PAYMENT && type == "TOPUP") ||
+          (status == COMPLETED && (type == "INAPP" || type == "INAPP_UNMANAGED")) ||
+          status == FAILED ||
+          status == CANCELED ||
+          status == INVALID_TRANSACTION
 
   fun getCompletePurchaseBundle(type: String, merchantName: String, sku: String?,
                                 orderReference: String?, hash: String?,
-                                scheduler: Scheduler): Single<Bundle> {
-    return if (isInApp(type) && sku != null) {
-      billing.getSkuPurchase(merchantName, sku, scheduler)
-          .map { billingMessagesMapper.mapPurchase(it, orderReference) }
-    } else {
-      Single.just(billingMessagesMapper.successBundle(hash))
-    }
-  }
+                                scheduler: Scheduler): Single<Bundle> =
+      if (isInApp(type) && sku != null) {
+        billing.getSkuPurchase(merchantName, sku, scheduler)
+            .map { billingMessagesMapper.mapPurchase(it, orderReference) }
+      } else {
+        Single.just(billingMessagesMapper.successBundle(hash))
+      }
 
-  private fun isInApp(type: String): Boolean {
-    return type.equals("INAPP", ignoreCase = true)
-  }
+  private fun isInApp(type: String) = type.equals("INAPP", ignoreCase = true)
 
   fun savePreSelectedPaymentMethod(paymentMethod: String) {
     inAppPurchaseInteractor.savePreSelectedPaymentMethod(paymentMethod)

--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/LocalPaymentInteractor.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/LocalPaymentInteractor.kt
@@ -51,7 +51,7 @@ class LocalPaymentInteractor(private val deepLinkRepository: InAppDeepLinkReposi
 
   private fun isEndingState(status: Transaction.Status, type: String) =
       (status == PENDING_USER_PAYMENT && type == "TOPUP") ||
-          (status == COMPLETED && (type == "INAPP" || type == "INAPP_UNMANAGED")) ||
+          status == COMPLETED ||
           status == FAILED ||
           status == CANCELED ||
           status == INVALID_TRANSACTION

--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/LocalPaymentInteractor.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/LocalPaymentInteractor.kt
@@ -77,4 +77,6 @@ class LocalPaymentInteractor(private val deepLinkRepository: InAppDeepLinkReposi
   }
 
   private data class DeepLinkInformation(val storeAddress: String, val oemAddress: String)
+
+  fun isAsync(type: String) = type == "TOPUP"
 }

--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/LocalPaymentPresenter.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/LocalPaymentPresenter.kt
@@ -158,9 +158,9 @@ class LocalPaymentPresenter(private val view: LocalPaymentView,
   }
 
   private fun isErrorStatus(transaction: Transaction) =
-      transaction.status != Status.FAILED &&
-          transaction.status != Status.CANCELED &&
-          transaction.status != Status.INVALID_TRANSACTION
+      transaction.status == Status.FAILED ||
+          transaction.status == Status.CANCELED ||
+          transaction.status == Status.INVALID_TRANSACTION
 
   private fun handleSyncCompletedStatus(transaction: Transaction): Completable {
     return localPaymentInteractor.getCompletePurchaseBundle(type, domain, skuId,

--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/LocalPaymentPresenter.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/LocalPaymentPresenter.kt
@@ -37,8 +37,7 @@ class LocalPaymentPresenter(private val view: LocalPaymentView,
                             private val orderReference: String?,
                             private val payload: String?,
                             private val context: Context?,
-                            private val paymentMethodIconUrl: String?,
-                            private val async: Boolean) {
+                            private val paymentMethodIconUrl: String?) {
 
   private var waitingResult: Boolean = false
 
@@ -152,7 +151,7 @@ class LocalPaymentPresenter(private val view: LocalPaymentView,
             .subscribeOn(networkScheduler)
             .observeOn(viewScheduler)
             .flatMapCompletable {
-              if (async) {
+              if (localPaymentInteractor.isAsync(type)) {
                 Completable.fromAction {
                   localPaymentInteractor.savePreSelectedPaymentMethod(paymentId)
                   localPaymentInteractor.saveAsyncLocalPayment(paymentId)

--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/LocalPaymentPresenter.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/LocalPaymentPresenter.kt
@@ -70,25 +70,21 @@ class LocalPaymentPresenter(private val view: LocalPaymentView,
             .subscribe({ view.showPendingUserPayment(it.first, it.second) }, { showError(it) }))
   }
 
-  private fun getPaymentMethodIcon(): Single<Bitmap> {
-    return Single.fromCallable {
-      GlideApp.with(context!!)
-          .asBitmap()
-          .load(paymentMethodIconUrl)
-          .override(getWidth(), getHeight())
-          .centerCrop()
-          .submit()
-          .get()
-    }
+  private fun getPaymentMethodIcon() = Single.fromCallable {
+    GlideApp.with(context!!)
+        .asBitmap()
+        .load(paymentMethodIconUrl)
+        .override(getWidth(), getHeight())
+        .centerCrop()
+        .submit()
+        .get()
   }
 
-  private fun getApplicationIconIcon(): Single<Bitmap> {
-    return Single.fromCallable {
-      val applicationIcon =
-          (context!!.packageManager.getApplicationIcon(domain) as BitmapDrawable).bitmap
+  private fun getApplicationIconIcon() = Single.fromCallable {
+    val applicationIcon =
+        (context!!.packageManager.getApplicationIcon(domain) as BitmapDrawable).bitmap
 
-      Bitmap.createScaledBitmap(applicationIcon, appIconWidth, appIconHeight, true)
-    }
+    Bitmap.createScaledBitmap(applicationIcon, appIconWidth, appIconHeight, true)
   }
 
   private fun onViewCreatedRequestLink() {
@@ -104,7 +100,8 @@ class LocalPaymentPresenter(private val view: LocalPaymentView,
                   paymentId)
               navigator.navigateToUriForResult(it)
               waitingResult = true
-            }.subscribeOn(networkScheduler)
+            }
+            .subscribeOn(networkScheduler)
             .observeOn(viewScheduler)
             .subscribe({ }, { showError(it) }))
   }
@@ -167,10 +164,12 @@ class LocalPaymentPresenter(private val view: LocalPaymentView,
         preparePendingUserPayment()
         analytics.sendPaymentEvent(domain, skuId, amount.toString(), type, paymentId)
         analytics.sendPaymentPendingEvent(domain, skuId, amount.toString(), type, paymentId)
-      }.subscribeOn(viewScheduler)
+      }
+          .subscribeOn(viewScheduler)
       else -> Completable.fromAction {
         view.showError()
-      }.subscribeOn(viewScheduler)
+      }
+          .subscribeOn(viewScheduler)
     }
   }
 

--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/LocalPaymentPresenter.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/LocalPaymentPresenter.kt
@@ -138,22 +138,18 @@ class LocalPaymentPresenter(private val view: LocalPaymentView,
 
   private fun handleTransactionStatus(transaction: Transaction): Completable {
     view.hideLoading()
-    return if (isErrorStatus(transaction)) {
-      Completable.fromAction { view.showError() }
+    return when {
+      isErrorStatus(transaction) -> Completable.fromAction { view.showError() }
           .subscribeOn(viewScheduler)
-    } else {
-      when {
-        localPaymentInteractor.isAsync(transaction.type) -> {
-          handleAsyncTransactionStatus(transaction)
-              .andThen(Completable.fromAction {
-                localPaymentInteractor.savePreSelectedPaymentMethod(paymentId)
-                localPaymentInteractor.saveAsyncLocalPayment(paymentId)
-                preparePendingUserPayment()
-              })
-        }
-        transaction.status == Status.COMPLETED -> handleSyncCompletedStatus(transaction)
-        else -> Completable.complete()
-      }
+      localPaymentInteractor.isAsync(transaction.type) ->
+        handleAsyncTransactionStatus(transaction)
+            .andThen(Completable.fromAction {
+              localPaymentInteractor.savePreSelectedPaymentMethod(paymentId)
+              localPaymentInteractor.saveAsyncLocalPayment(paymentId)
+              preparePendingUserPayment()
+            })
+      transaction.status == Status.COMPLETED -> handleSyncCompletedStatus(transaction)
+      else -> Completable.complete()
     }
   }
 

--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/PaymentMethodsPresenter.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/PaymentMethodsPresenter.kt
@@ -245,6 +245,7 @@ class PaymentMethodsPresenter(
     val fiatAmount = formatter.formatCurrency(fiatValue.amount, WalletCurrency.FIAT)
     val appcAmount = formatter.formatCurrency(transaction.amount(), WalletCurrency.APPCOINS)
     if (inAppPurchaseInteractor.hasAsyncLocalPayment()) {
+      //After a asynchronous payment credits will be used as pre selected
       getCreditsPaymentMethod(paymentMethods)?.let {
         if (it.isEnabled) {
           showPreSelectedPaymentMethod(fiatValue, it, fiatAmount, appcAmount, isBonusActive)


### PR DESCRIPTION
**What does this PR do?**

     This PR changes the way we show the async payment dialog. It is now presented when transaction status is completed to prevent the users for paying before leaving the webview

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] LocalPaymentFragment.kt
- [ ] LocalPaymentPresenter.kt

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [MOB-605](https://aptoide.atlassian.net/browse/MOB-605)

**What are the relevant tickets?**

  Tickets related to this pull-request: [MOB-605](https://aptoide.atlassian.net/browse/MOB-605)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new libs, new keys, etc.)




**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass