### PR TITLE
Bugfix/mob 680 keyboard is not hidden when leaving validation flow

### DIFF
--- a/app/src/main/java/com/asfoundation/wallet/ui/BaseActivity.java
+++ b/app/src/main/java/com/asfoundation/wallet/ui/BaseActivity.java
@@ -1,17 +1,16 @@
 package com.asfoundation.wallet.ui;
 
-import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
 import android.view.MenuItem;
 import android.view.Window;
 import android.view.WindowManager;
-import android.view.inputmethod.InputMethodManager;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.Toolbar;
 import com.asf.wallet.R;
+import com.asfoundation.wallet.util.KeyboardUtils;
 import com.google.android.material.appbar.CollapsingToolbarLayout;
 import java.util.ArrayList;
 import java.util.List;
@@ -87,7 +86,8 @@ public abstract class BaseActivity extends AppCompatActivity implements Activity
 
   @Override public boolean onOptionsItemSelected(MenuItem item) {
     if (item.getItemId() == android.R.id.home) {
-      hideKeyboard();
+      KeyboardUtils.hideKeyboard(getWindow().getDecorView()
+          .getRootView());
       finish();
     }
     return true;
@@ -107,12 +107,5 @@ public abstract class BaseActivity extends AppCompatActivity implements Activity
     for (ActivityResultListener listener : activityResultListeners) {
       listener.onActivityResult(requestCode, resultCode, data);
     }
-  }
-
-  private void hideKeyboard() {
-    InputMethodManager imm = (InputMethodManager) getSystemService(Context.INPUT_METHOD_SERVICE);
-    imm.hideSoftInputFromWindow(getWindow().getDecorView()
-        .getRootView()
-        .getWindowToken(), 0);
   }
 }

--- a/app/src/main/java/com/asfoundation/wallet/ui/BaseActivity.java
+++ b/app/src/main/java/com/asfoundation/wallet/ui/BaseActivity.java
@@ -1,10 +1,12 @@
 package com.asfoundation.wallet.ui;
 
+import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
 import android.view.MenuItem;
 import android.view.Window;
 import android.view.WindowManager;
+import android.view.inputmethod.InputMethodManager;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AppCompatActivity;
@@ -85,6 +87,7 @@ public abstract class BaseActivity extends AppCompatActivity implements Activity
 
   @Override public boolean onOptionsItemSelected(MenuItem item) {
     if (item.getItemId() == android.R.id.home) {
+      hideKeyboard();
       finish();
     }
     return true;
@@ -104,5 +107,12 @@ public abstract class BaseActivity extends AppCompatActivity implements Activity
     for (ActivityResultListener listener : activityResultListeners) {
       listener.onActivityResult(requestCode, resultCode, data);
     }
+  }
+
+  private void hideKeyboard() {
+    InputMethodManager imm = (InputMethodManager) getSystemService(Context.INPUT_METHOD_SERVICE);
+    imm.hideSoftInputFromWindow(getWindow().getDecorView()
+        .getRootView()
+        .getWindowToken(), 0);
   }
 }


### PR DESCRIPTION
**What does this PR do?**

Fix bug that caused keyboard to keep showing after user presses back in CodeValidationFragment.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] BaseActivity.java

**How should this be manually tested?**

Start the wallet validation flow, enter a valid number and press next; when the input for the received PIN is shown, press the "Back" arrow in the toolbar.

**What are the relevant tickets?**

  Tickets related to this pull-request: [MOB-680](https://aptoide.atlassian.net/browse/MOB-680)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new libs, new keys, etc.)

No


**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass