### PR TITLE
[MOB-658] Fixed loading visible when nothing was loading. included share backup mimetype

### DIFF
--- a/app/src/main/java/com/asfoundation/wallet/topup/TopUpFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/topup/TopUpFragment.kt
@@ -317,6 +317,11 @@ class TopUpFragment : DaggerFragment(), TopUpFragmentView {
     button_loading.visibility = View.GONE
   }
 
+  override fun showLoadingButton() {
+    button.visibility = View.INVISIBLE
+    button_loading.visibility = View.VISIBLE
+  }
+
   override fun showPaymentDetailsForm() {
     payment_methods.visibility = View.GONE
     loading.visibility = View.GONE

--- a/app/src/main/java/com/asfoundation/wallet/topup/TopUpFragmentPresenter.kt
+++ b/app/src/main/java/com/asfoundation/wallet/topup/TopUpFragmentPresenter.kt
@@ -66,6 +66,7 @@ class TopUpFragmentPresenter(private val view: TopUpFragmentView,
           updateDefaultValues(defaultValues)
           view.hideButtonLoading()
         })
+        .doOnSubscribe { view.showLoadingButton() }
         .subscribe({}, { handleError(it) }))
   }
 

--- a/app/src/main/java/com/asfoundation/wallet/topup/TopUpFragmentView.kt
+++ b/app/src/main/java/com/asfoundation/wallet/topup/TopUpFragmentView.kt
@@ -18,6 +18,7 @@ interface TopUpFragmentView {
   fun showLoading()
   fun hideLoading()
   fun hideButtonLoading()
+  fun showLoadingButton()
   fun showPaymentDetailsForm()
   fun showPaymentMethods()
   fun rotateChangeCurrencyButton()

--- a/app/src/main/java/com/asfoundation/wallet/topup/payment/AdyenTopUpFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/topup/payment/AdyenTopUpFragment.kt
@@ -423,6 +423,7 @@ class AdyenTopUpFragment : DaggerFragment(), AdyenTopUpView {
 
     topUpView.showToolbar()
     main_value.visibility = INVISIBLE
+    button.visibility = VISIBLE
   }
 
   private fun setupCardConfiguration() {

--- a/app/src/main/java/com/asfoundation/wallet/ui/backup/BackupCreationFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/backup/BackupCreationFragment.kt
@@ -100,7 +100,7 @@ class BackupCreationFragment : BackupCreationView, DaggerFragment() {
   override fun shareFile(uri: Uri) {
     ShareCompat.IntentBuilder.from(activity)
         .setStream(uri)
-        .setType("text/plain")
+        .setType("text/json")
         .setSubject(getString(R.string.tab_keystore))
         .setChooserTitle(R.string.share_via)
         .startChooser()

--- a/app/src/main/res/layout/fragment_top_up.xml
+++ b/app/src/main/res/layout/fragment_top_up.xml
@@ -268,7 +268,7 @@
           android:layout_width="@dimen/button_height"
           android:layout_height="@dimen/button_height"
           android:indeterminateDrawable="@drawable/gradient_progress"
-          android:visibility="visible"
+          android:visibility="gone"
           app:layout_constraintBottom_toBottomOf="@+id/button"
           app:layout_constraintTop_toTopOf="@+id/button"
           app:layout_constraintStart_toStartOf="@+id/button"


### PR DESCRIPTION

**What does this PR do?**

   This PR fixes an issue with loading indicator showing when nothing was being loaded. Also it was included the fix for the share backup mime type

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] TopUpFragment.kt
- [ ] TopUpFragmentPresenter.kt
- [ ] TopUpFragmentView.kt

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [MOB-658](https://aptoide.atlassian.net/browse/MOB-658)

**What are the relevant tickets?**

  Tickets related to this pull-request: [MOB-658](https://aptoide.atlassian.net/browse/MOB-658)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new libs, new keys, etc.)




**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass