### PR TITLE
[MOB-731] Wrong texts are showing on async payment notification

### DIFF
--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/LocalPaymentFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/LocalPaymentFragment.kt
@@ -347,7 +347,7 @@ class LocalPaymentFragment : DaggerFragment(), LocalPaymentView {
     progress_bar.visibility = View.GONE
     pending_user_payment_view?.visibility = View.VISIBLE
 
-    val placeholder = getString(R.string.async_steps_1)
+    val placeholder = getString(R.string.async_steps_1_no_notification)
     val stepOneText = String.format(placeholder, paymentMethodIconLabel)
 
     step_one_desc.text = stepOneText

--- a/app/src/main/res/layout-land/pending_user_payment_view.xml
+++ b/app/src/main/res/layout-land/pending_user_payment_view.xml
@@ -68,7 +68,7 @@
       app:layout_constraintHorizontal_bias="0"
       app:layout_constraintStart_toEndOf="@id/step_one"
       app:layout_constraintTop_toBottomOf="@id/in_progress_animation"
-      tools:text="Complete your payment with GO-PAY"
+      tools:text="@string/async_steps_1_no_notification"
       tools:visibility="visible"
       />
 

--- a/app/src/main/res/layout-land/pending_user_payment_view.xml
+++ b/app/src/main/res/layout-land/pending_user_payment_view.xml
@@ -98,7 +98,7 @@
       android:layout_marginStart="@dimen/big_margin"
       android:layout_marginTop="4dp"
       android:layout_marginEnd="@dimen/big_margin"
-      android:text="@string/async_steps_2"
+      android:text="@string/async_steps_2_no_notification"
       android:textColor="@color/pending_payment_text_color"
       android:textSize="12sp"
       android:visibility="invisible"

--- a/app/src/main/res/layout/pending_user_payment_view.xml
+++ b/app/src/main/res/layout/pending_user_payment_view.xml
@@ -70,7 +70,7 @@
       app:layout_constraintHorizontal_bias="0"
       app:layout_constraintStart_toEndOf="@id/step_one"
       app:layout_constraintTop_toBottomOf="@id/in_progress_animation"
-      tools:text="@string/async_steps_1"
+      tools:text="@string/async_steps_1_no_notification"
       tools:visibility="visible"
       />
 
@@ -100,7 +100,7 @@
       android:layout_marginStart="@dimen/big_margin"
       android:layout_marginTop="@dimen/big_margin"
       android:layout_marginEnd="@dimen/big_margin"
-      android:text="@string/async_steps_2"
+      android:text="@string/async_steps_2_no_notification"
       android:textColor="@color/pending_payment_text_color"
       android:textSize="12sp"
       android:visibility="invisible"


### PR DESCRIPTION


**What does this PR do?**

 Fixed texts used on async payment dialog to show the text were no reference to notification is done

**Where should the reviewer start?**

- [ ] LocalPaymentFragment.kt
- [ ] pending_user_payment_view.xml
- [ ] pending_user_payment_view.xml

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [MOB-731](https://aptoide.atlassian.net/browse/MOB-731)

**What are the relevant tickets?**

  Tickets related to this pull-request: [MOB-731](https://aptoide.atlassian.net/browse/MOB-731)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new libs, new keys, etc.)




**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass