### PR TITLE
[MOB-726] Fixed backup notification not showing for every 2 purchases if not dismissed

### DIFF
--- a/app/src/main/java/com/asfoundation/wallet/backup/BackupInteract.kt
+++ b/app/src/main/java/com/asfoundation/wallet/backup/BackupInteract.kt
@@ -110,7 +110,7 @@ class BackupInteract(
   override fun shouldShowSystemNotification(walletAddress: String): Boolean {
     val hasRestoredBackup = sharedPreferencesRepository.isWalletRestoreBackup(walletAddress)
     val count = sharedPreferencesRepository.getWalletPurchasesCount(walletAddress)
-    return if (hasRestoredBackup.not() && count >= PURCHASE_NOTIFICATION_THRESHOLD) {
+    return if (hasRestoredBackup.not() && count % PURCHASE_NOTIFICATION_THRESHOLD == 0) {
       sharedPreferencesRepository.hasDismissedBackupSystemNotification(walletAddress)
           .not()
     } else {

--- a/app/src/main/java/com/asfoundation/wallet/backup/BackupInteract.kt
+++ b/app/src/main/java/com/asfoundation/wallet/backup/BackupInteract.kt
@@ -110,7 +110,7 @@ class BackupInteract(
   override fun shouldShowSystemNotification(walletAddress: String): Boolean {
     val hasRestoredBackup = sharedPreferencesRepository.isWalletRestoreBackup(walletAddress)
     val count = sharedPreferencesRepository.getWalletPurchasesCount(walletAddress)
-    return if (hasRestoredBackup.not() && count % PURCHASE_NOTIFICATION_THRESHOLD == 0) {
+    return if (hasRestoredBackup.not() && count > 0 && count % PURCHASE_NOTIFICATION_THRESHOLD == 0) {
       sharedPreferencesRepository.hasDismissedBackupSystemNotification(walletAddress)
           .not()
     } else {

--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/IabPresenter.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/IabPresenter.kt
@@ -31,8 +31,9 @@ class IabPresenter(private val view: IabView,
             .subscribeOn(networkScheduler)
             .observeOn(viewScheduler)
             .doOnSuccess { notificationNeeded ->
-              if (notificationNeeded.isNeeded)
+              if (notificationNeeded.isNeeded) {
                 view.showBackupNotification(notificationNeeded.walletAddress)
+              }
               view.finishActivity(bundle)
             }
             .doOnError { view.finish(bundle) }
@@ -87,7 +88,8 @@ class IabPresenter(private val view: IabView,
   }
 
   fun savePreselectedPaymentMethod(bundle: Bundle) {
-    bundle.getString(PRE_SELECTED_PAYMENT_METHOD_KEY)?.let {
+    bundle.getString(PRE_SELECTED_PAYMENT_METHOD_KEY)
+        ?.let {
           iabInteract.savePreSelectedPaymentMethod(it)
         }
   }


### PR DESCRIPTION
**What does this PR do?**

   This PR fixes the backup notification that should only be showed every 2 purchases instead of one. 

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] BackupInteract.kt

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [MOB-726](https://aptoide.atlassian.net/browse/MOB-726)

**What are the relevant tickets?**

  Tickets related to this pull-request: [MOB-726](https://aptoide.atlassian.net/browse/MOB-726)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new libs, new keys, etc.)




**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass