### PR TITLE
[MOB-767] Allow gamification to be shown when referrals are inactive

### DIFF
--- a/app/src/main/java/com/asfoundation/wallet/promotions/PromotionsPresenter.kt
+++ b/app/src/main/java/com/asfoundation/wallet/promotions/PromotionsPresenter.kt
@@ -39,11 +39,7 @@ class PromotionsPresenter(private val view: PromotionsView,
 
   private fun onPromotions(promotionsModel: PromotionsModel) {
     view.hideLoading()
-    if (promotionsModel.gamificationAvailable && promotionsModel.referralsAvailable) {
-      view.setReferralBonus(
-          formatter.formatCurrency(promotionsModel.maxValue, WalletCurrency.FIAT),
-          promotionsModel.currency)
-      view.toggleShareAvailability(promotionsModel.isValidated)
+    if (promotionsModel.gamificationAvailable || promotionsModel.referralsAvailable) {
       showPromotions(promotionsModel)
     } else {
       view.showNoPromotionsScreen()
@@ -104,6 +100,10 @@ class PromotionsPresenter(private val view: PromotionsView,
 
   private fun showPromotions(promotionsModel: PromotionsModel) {
     if (promotionsModel.referralsAvailable) {
+      view.setReferralBonus(
+          formatter.formatCurrency(promotionsModel.maxValue, WalletCurrency.FIAT),
+          promotionsModel.currency)
+      view.toggleShareAvailability(promotionsModel.isValidated)
       view.showReferralCard()
       checkForReferralsUpdates(promotionsModel)
     }


### PR DESCRIPTION
Fix condition that was not showing gamification when only the referrals is inactive

**What does this PR do?**

   A few sentences describing the overall goals of the pull request's commits.

   Explain any technical decisions that were made and why (when it makes sense).

**Database changed?**

   Yes | No

**Where should the reviewer start?**

- [ ] PromotionsPresenter.kt

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [MOB-767](https://aptoide.atlassian.net/browse/MOB-767)

**What are the relevant tickets?**

  Tickets related to this pull-request: [MOB-767](https://aptoide.atlassian.net/browse/MOB-767)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new libs, new keys, etc.)




**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass