### PR TITLE
[MOB-834] Crash on backup legacy flow

### DIFF
--- a/app/src/main/java/com/asfoundation/wallet/interact/RestoreWalletInteractor.kt
+++ b/app/src/main/java/com/asfoundation/wallet/interact/RestoreWalletInteractor.kt
@@ -18,9 +18,7 @@ class RestoreWalletInteractor(private val walletRepository: WalletRepositoryType
                               private val preferencesRepositoryType: PreferencesRepositoryType,
                               private val fileInteractor: FileInteractor) {
 
-  fun isKeystore(key: String): Boolean {
-    return key.contains("{")
-  }
+  fun isKeystore(key: String) = key.contains("{")
 
   fun restoreKeystore(keystore: String, password: String = ""): Single<WalletModel> {
     return passwordStore.generatePassword()

--- a/app/src/main/java/com/asfoundation/wallet/service/Web3jKeystoreAccountService.java
+++ b/app/src/main/java/com/asfoundation/wallet/service/Web3jKeystoreAccountService.java
@@ -61,7 +61,7 @@ public class Web3jKeystoreAccountService implements AccountKeystoreService {
             return importKeystoreInternal(store, password, newPassword);
           }
         })
-        .doOnError(throwable -> throwable.printStackTrace());
+        .doOnError(Throwable::printStackTrace);
   }
 
   @Override public Single<Wallet> restorePrivateKey(String privateKey, String newPassword) {
@@ -170,7 +170,7 @@ public class Web3jKeystoreAccountService implements AccountKeystoreService {
     try {
       JsonObject keyStore = JsonParser.parseString(keystore)
           .getAsJsonObject();
-      return keyStore.get("address")
+      return "0x" + keyStore.get("address")
           .getAsString();
     } catch (Exception ex) {
       throw new Exception("Invalid keystore: " + keystore);

--- a/app/src/main/java/com/asfoundation/wallet/service/Web3jKeystoreAccountService.java
+++ b/app/src/main/java/com/asfoundation/wallet/service/Web3jKeystoreAccountService.java
@@ -4,14 +4,14 @@ import com.asfoundation.wallet.C;
 import com.asfoundation.wallet.entity.ServiceErrorException;
 import com.asfoundation.wallet.entity.Wallet;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import io.reactivex.Completable;
 import io.reactivex.Single;
 import java.io.File;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.List;
-import org.json.JSONException;
-import org.json.JSONObject;
 import org.spongycastle.util.encoders.Hex;
 import org.web3j.crypto.Credentials;
 import org.web3j.crypto.ECKeyPair;
@@ -60,7 +60,8 @@ public class Web3jKeystoreAccountService implements AccountKeystoreService {
           } else {
             return importKeystoreInternal(store, password, newPassword);
           }
-        });
+        })
+        .doOnError(throwable -> throwable.printStackTrace());
   }
 
   @Override public Single<Wallet> restorePrivateKey(String privateKey, String newPassword) {
@@ -165,12 +166,14 @@ public class Web3jKeystoreAccountService implements AccountKeystoreService {
     }
   }
 
-  private String extractAddressFromStore(String store) throws Exception {
+  private String extractAddressFromStore(String keystore) throws Exception {
     try {
-      JSONObject jsonObject = new JSONObject(store);
-      return "0x" + jsonObject.getString("address");
-    } catch (JSONException ex) {
-      throw new Exception("Invalid keystore: " + store);
+      JsonObject keyStore = JsonParser.parseString(keystore)
+          .getAsJsonObject();
+      return keyStore.get("address")
+          .getAsString();
+    } catch (Exception ex) {
+      throw new Exception("Invalid keystore: " + keystore);
     }
   }
 }

--- a/app/src/main/java/com/asfoundation/wallet/ui/balance/RestoreWalletPasswordInteractor.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/balance/RestoreWalletPasswordInteractor.kt
@@ -11,9 +11,9 @@ class RestoreWalletPasswordInteractor(private val gson: Gson,
                                       private val balanceInteract: BalanceInteract,
                                       private val restoreWalletInteractor: RestoreWalletInteractor) {
 
-  fun extractWalletAddress(keystore: String): Single<String> {
+  fun extractWalletAddress(keystore: String): Single<String> = Single.create {
     val parsedKeystore = gson.fromJson(keystore, Keystore::class.java)
-    return Single.just("0x" + parsedKeystore.address)
+    it.onSuccess("0x" + parsedKeystore.address)
   }
 
   fun getOverallBalance(address: String): Observable<FiatValue> =

--- a/app/src/main/java/com/asfoundation/wallet/ui/balance/RestoreWalletPasswordPresenter.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/balance/RestoreWalletPasswordPresenter.kt
@@ -29,7 +29,11 @@ class RestoreWalletPasswordPresenter(private val view: RestoreWalletPasswordView
               .observeOn(viewScheduler)
               .doOnNext { fiatValue -> view.updateUi(address, fiatValue) }
         }
-        .subscribe({}, { it.printStackTrace() }))
+        .observeOn(viewScheduler)
+        .subscribe({}, {
+          it.printStackTrace()
+          view.showError(RestoreErrorType.GENERIC)
+        }))
   }
 
   private fun handleRestoreWalletButtonClicked(keystore: String) {


### PR DESCRIPTION

**What does this PR do?**

This PR fixes a crash happening if the keystore had an invalid format. Also it improves the RestoreWalletPassword flow that didn't handle all error cases

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] RestoreWalletInteractor.kt
- [ ] RestoreWalletPasswordInteractor.kt
- [ ] RestoreWalletPasswordPresenter.kt
- [ ] Web3jKeystoreAccountService.java
**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [MOB-834](https://aptoide.atlassian.net/browse/MOB-834)

**What are the relevant tickets?**

  Tickets related to this pull-request: [MOB-834](https://aptoide.atlassian.net/browse/MOB-834)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new libs, new keys, etc.)




**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass