### PR TITLE
[MOB-951] Item description is no longer null on topup local payment

### DIFF
--- a/app/src/main/java/com/asfoundation/wallet/topup/LocalTopUpPaymentPresenter.kt
+++ b/app/src/main/java/com/asfoundation/wallet/topup/LocalTopUpPaymentPresenter.kt
@@ -6,6 +6,7 @@ import android.os.Bundle
 import android.util.TypedValue
 import com.appcoins.wallet.bdsbilling.repository.entity.Transaction
 import com.appcoins.wallet.billing.BillingMessagesMapper
+import com.asf.wallet.R
 import com.asfoundation.wallet.GlideApp
 import com.asfoundation.wallet.logging.Logger
 import com.asfoundation.wallet.ui.iab.LocalPaymentInteractor
@@ -96,7 +97,7 @@ class LocalTopUpPaymentPresenter(
 
   private fun onViewCreatedRequestLink() {
     disposables.add(localPaymentInteractor.getTopUpPaymentLink(packageName, data.fiatValue,
-        data.fiatCurrencyCode, paymentId)
+        data.fiatCurrencyCode, paymentId, context?.getString(R.string.topup_title) ?: "Top up")
         .filter { !waitingResult && it.isNotEmpty() }
         .observeOn(viewScheduler)
         .doOnSuccess {

--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/LocalPaymentInteractor.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/LocalPaymentInteractor.kt
@@ -65,7 +65,8 @@ class LocalPaymentInteractor(private val deepLinkRepository: InAppDeepLinkReposi
 
     return walletService.getAndSignCurrentWalletAddress()
         .flatMap { walletAddressModel ->
-          remoteRepository.createLocalPaymentTransaction(paymentMethod, packageName, fiatAmount,
+          remoteRepository.createLocalPaymentTopUpTransaction(paymentMethod, packageName,
+              fiatAmount,
               fiatCurrency, walletAddressModel.address, walletAddressModel.signedAddress)
         }
         .map { it.url ?: "" }

--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/LocalPaymentInteractor.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/LocalPaymentInteractor.kt
@@ -61,13 +61,14 @@ class LocalPaymentInteractor(private val deepLinkRepository: InAppDeepLinkReposi
   }
 
   fun getTopUpPaymentLink(packageName: String, fiatAmount: String,
-                          fiatCurrency: String, paymentMethod: String): Single<String> {
+                          fiatCurrency: String, paymentMethod: String,
+                          productName: String): Single<String> {
 
     return walletService.getAndSignCurrentWalletAddress()
         .flatMap { walletAddressModel ->
           remoteRepository.createLocalPaymentTopUpTransaction(paymentMethod, packageName,
-              fiatAmount,
-              fiatCurrency, walletAddressModel.address, walletAddressModel.signedAddress)
+              fiatAmount, fiatCurrency, productName, walletAddressModel.address,
+              walletAddressModel.signedAddress)
         }
         .map { it.url ?: "" }
   }

--- a/bdsbilling/src/main/java/com/appcoins/wallet/bdsbilling/repository/RemoteRepository.kt
+++ b/bdsbilling/src/main/java/com/appcoins/wallet/bdsbilling/repository/RemoteRepository.kt
@@ -118,12 +118,12 @@ class RemoteRepository(private val api: BdsApi, private val responseMapper: BdsA
         null).ignoreElement()
   }
 
-  fun createLocalPaymentTransaction(paymentId: String, packageName: String, price: String,
-                                    currency: String, walletAddress: String,
-                                    walletSignature: String): Single<Transaction> {
+  fun createLocalPaymentTopUpTransaction(paymentId: String, packageName: String, price: String,
+                                         currency: String, walletAddress: String,
+                                         walletSignature: String): Single<Transaction> {
     return createTransaction(walletAddress, null, null, null, null, null, null, null, null, null,
-        "TOPUP", "myappcoins", walletAddress, walletSignature, packageName, price, currency, null,
-        LocalPaymentBody(price, currency, packageName, "TOPUP", paymentId))
+        "TOPUP", "myappcoins", walletAddress, walletSignature, packageName, price, currency,
+        null, LocalPaymentBody(price, currency, packageName, "TOPUP", paymentId, "Top Up"))
   }
 
   private fun createTransaction(userWallet: String?, developerWallet: String?, storeWallet: String?,
@@ -134,7 +134,7 @@ class RemoteRepository(private val api: BdsApi, private val responseMapper: BdsA
                                 amount: String, currency: String, productName: String?,
                                 localPaymentBody: LocalPaymentBody = LocalPaymentBody()): Single<Transaction> {
     return if (gateway == "myappcoins") {
-      api.createTransaction(null, packageName, amount, currency, null,
+      api.createTransaction(null, packageName, amount, currency, productName,
           type, walletAddress, null, null, null, null, null, null, null, null, walletAddress,
           signature, localPaymentBody)
     } else {
@@ -290,7 +290,8 @@ class RemoteRepository(private val api: BdsApi, private val responseMapper: BdsA
 
   data class LocalPaymentBody(@SerializedName("price.value") val price: String,
                               @SerializedName("price.currency") val currency: String,
-                              val domain: String, val type: String, val method: String) {
-    constructor() : this("", "", "", "", "")
+                              val domain: String, val type: String, val method: String,
+                              val product: String) {
+    constructor() : this("", "", "", "", "", "")
   }
 }

--- a/bdsbilling/src/main/java/com/appcoins/wallet/bdsbilling/repository/RemoteRepository.kt
+++ b/bdsbilling/src/main/java/com/appcoins/wallet/bdsbilling/repository/RemoteRepository.kt
@@ -119,11 +119,12 @@ class RemoteRepository(private val api: BdsApi, private val responseMapper: BdsA
   }
 
   fun createLocalPaymentTopUpTransaction(paymentId: String, packageName: String, price: String,
-                                         currency: String, walletAddress: String,
+                                         currency: String, productName: String,
+                                         walletAddress: String,
                                          walletSignature: String): Single<Transaction> {
     return createTransaction(walletAddress, null, null, null, null, null, null, null, null, null,
         "TOPUP", "myappcoins", walletAddress, walletSignature, packageName, price, currency,
-        null, LocalPaymentBody(price, currency, packageName, "TOPUP", paymentId, "Top Up"))
+        null, LocalPaymentBody(price, currency, packageName, "TOPUP", paymentId, productName))
   }
 
   private fun createTransaction(userWallet: String?, developerWallet: String?, storeWallet: String?,


### PR DESCRIPTION
**What does this PR do?**

Add product name on topup so that the webview displays a name instead of null

**Database changed?**

No

**Where should the reviewer start?**

- LocalTopUpPaymentPresenter.kt

**How should this be manually tested?**

Try to do a payment with a local payment on topup and check if the webview doesn't show null on the item field

**What are the relevant tickets?**

https://aptoide.atlassian.net/browse/MOB-951

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new libs, new keys, etc.)




**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass