### PR TITLE
[MOB-1009] Fixed bug where we were displaying the gamification progress as 100% even if there were needed more appc spent

### DIFF
--- a/app/src/main/java/com/asfoundation/wallet/ui/gamification/CurrentLevelViewHolder.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/gamification/CurrentLevelViewHolder.kt
@@ -73,12 +73,12 @@ class CurrentLevelViewHolder(itemView: View,
 
   private fun getProgressPercentage(levelAmount: BigDecimal): BigDecimal {
     return if (nextLevelAmount != null) {
-      var levelRange = nextLevelAmount - levelAmount
+      var levelRange = nextLevelAmount.subtract(levelAmount)
       if (levelRange.toDouble() == 0.0) {
         levelRange = BigDecimal.ONE
       }
-      val amountSpentInLevel = amountSpent - levelAmount
-      amountSpentInLevel.divide(levelRange, 2, RoundingMode.HALF_EVEN)
+      val amountSpentInLevel = amountSpent.subtract(levelAmount)
+      amountSpentInLevel.divide(levelRange, 2, RoundingMode.DOWN)
           .multiply(BigDecimal(100))
     } else {
       BigDecimal(100)


### PR DESCRIPTION

**What does this PR do?**

An error was detected, when a user reaches almost 100% of a level only needing to spend 3.86 appcoins credits to reach the next level we are showing a 100% progress bar when it should be 99% because the user has not reached the next level yet.

**Database changed?**

   Yes | No

**Where should the reviewer start?**

- [ ] CurrentLevelViewHolder

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [MOB-1009](https://aptoide.atlassian.net/browse/MOB-1009)

**What are the relevant tickets?**

  Tickets related to this pull-request: [MOB-1009](https://aptoide.atlassian.net/browse/MOB-1009)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new libs, new keys, etc.)




**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass