### PR TITLE
[bugfix/WAL-37] Skeleton Payment Options fix

### DIFF
--- a/app/src/main/res/layout-land/payment_methods_layout.xml
+++ b/app/src/main/res/layout-land/payment_methods_layout.xml
@@ -140,6 +140,7 @@
           app:layout_constraintStart_toStartOf="@id/bonus_layout"
           app:layout_constraintTop_toBottomOf="@+id/bonus_layout"
           app:layout_constraintVertical_bias="1"
+          app:layout_constraintWidth_default="wrap"
           tools:visibility="visible"
           />
 

--- a/app/src/main/res/layout/payment_methods_layout.xml
+++ b/app/src/main/res/layout/payment_methods_layout.xml
@@ -281,8 +281,8 @@
             layout="@layout/skeleton_rounded_rectangle"
             android:layout_width="match_parent"
             android:layout_height="0dp"
-            android:layout_marginStart="42dp"
-            android:layout_marginEnd="42dp"
+            android:layout_marginStart="16dp"
+            android:layout_marginEnd="16dp"
             app:layout_constraintBottom_toBottomOf="@id/bonus_msg"
             app:layout_constraintTop_toTopOf="@id/bonus_msg"
             />

--- a/app/src/main/res/layout/payment_methods_layout.xml
+++ b/app/src/main/res/layout/payment_methods_layout.xml
@@ -253,7 +253,7 @@
         <TextView
             android:id="@+id/bonus_msg"
             style="@style/TopUpTextStyle.Small.BonusText"
-            android:layout_width="match_parent"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginStart="@dimen/big_margin"
             android:layout_marginTop="11dp"
@@ -261,9 +261,11 @@
             android:layout_marginBottom="20dp"
             android:gravity="center"
             android:text="@string/gamification_purchase_body"
+            app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/bonus_layout"
             app:layout_constraintVertical_bias="0"
+            app:layout_constraintWidth_default="wrap"
             />
 
         <include
@@ -279,11 +281,11 @@
         <include
             android:id="@+id/bonus_msg_skeleton"
             layout="@layout/skeleton_rounded_rectangle"
-            android:layout_width="match_parent"
+            android:layout_width="0dp"
             android:layout_height="0dp"
-            android:layout_marginStart="16dp"
-            android:layout_marginEnd="16dp"
             app:layout_constraintBottom_toBottomOf="@id/bonus_msg"
+            app:layout_constraintEnd_toEndOf="@id/bonus_msg"
+            app:layout_constraintStart_toStartOf="@id/bonus_msg"
             app:layout_constraintTop_toTopOf="@id/bonus_msg"
             />
         <TextView


### PR DESCRIPTION
**What does this PR do?**

   This changes one the fields skeleton view (bonus info textview) to match the size of the original.

**Database changed?**

   No

**How should this be manually tested?**

  Go to trivial drive and check the payments options dialog (on Russian language). The bonus info message should not appear behind the skeleton.

**What are the relevant tickets?**

 [WAL-37](https://aptoide.atlassian.net/browse/WAL-37)

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass