### PR TITLE
[bugfix/WAL-36] Landscape backup wallet dialog bug

### DIFF
--- a/app/src/main/res/layout/backup_dialog.xml
+++ b/app/src/main/res/layout/backup_dialog.xml
@@ -66,12 +66,14 @@
       tools:text="/Storage/downloads/backup"
       tools:visibility="visible"
       />
-  <EditText
+  <com.google.android.material.textfield.TextInputEditText
       android:id="@+id/edit_text_name"
       android:layout_width="0dp"
       android:layout_height="wrap_content"
       android:layout_marginTop="4dp"
       android:layout_marginEnd="20dp"
+      android:inputType="textImeMultiLine"
+      android:imeOptions="actionDone"
       app:layout_constraintEnd_toEndOf="parent"
       app:layout_constraintHorizontal_bias="0"
       app:layout_constraintStart_toStartOf="@id/store_path"


### PR DESCRIPTION
**What does this PR do?**

   This PR fixes an issue where in some small devices, on landscape, the multiline field was hiding the buttons, and there was no easy way to proceed, since there was no "done" action on keyboard.
   The way I fixed it was to basically turn it into a single line with an action button. I've tried several combinations with multiline that did not work because having multiline support means supporting line breaks, so the only combination that worked was a single line with horizontal scroll. Also, personally I think it should be single line in the first place. File names should not be multiline.

**Database changed?**

   No

**How should this be manually tested?**

  Go to backup wallet -> Save backup -> Dismiss share popup -> "No, save on device". Now on editing the file name, the action button should be "done", and there should not be more than one line.

**What are the relevant tickets?**

  Tickets related to this pull-request: [WAL-36](https://aptoide.atlassian.net/browse/WAL-36)

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass