### PR TITLE
[bugfix/WAL-39] Cancel Payment - Infinite Loading

### DIFF
--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/BillingWebViewFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/BillingWebViewFragment.kt
@@ -47,6 +47,8 @@ class BillingWebViewFragment : BasePageViewFragment() {
         "https://airtime.codapayments.com/epcgw/dlocal/"
     private const val CODAPAY_BACK_URL =
         "https://pay.dlocal.com/payment_method_connectors/global_pm//back"
+    private const val CODAPAY_CANCEL_URL =
+        "codapayments.com/airtime/cancelConfirm"
     private const val URL = "url"
     private const val CURRENT_URL = "currentUrl"
     private const val ORDER_ID_PARAMETER = "OrderId"
@@ -97,6 +99,8 @@ class BillingWebViewFragment : BasePageViewFragment() {
           val orderId = Uri.parse(clickUrl)
               .getQueryParameter(ORDER_ID_PARAMETER)
           finishWithSuccess(LOCAL_PAYMENTS_URL + orderId)
+        } else if (clickUrl.contains(CODAPAY_CANCEL_URL)) {
+          finishWithFail(clickUrl)
         } else {
           currentUrl = clickUrl
           return false
@@ -166,6 +170,13 @@ class BillingWebViewFragment : BasePageViewFragment() {
     val intent = Intent()
     intent.data = Uri.parse(url)
     webViewActivity!!.setResult(WebViewActivity.SUCCESS, intent)
+    webViewActivity!!.finish()
+  }
+
+  private fun finishWithFail(url: String) {
+    val intent = Intent()
+    intent.data = Uri.parse(url)
+    webViewActivity!!.setResult(WebViewActivity.FAIL, intent)
     webViewActivity!!.finish()
   }
 }

--- a/app/src/main/java/com/asfoundation/wallet/ui/iab/IabActivity.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/iab/IabActivity.kt
@@ -89,7 +89,9 @@ class IabActivity : BaseActivity(), IabView, UriNavigator {
     super.onActivityResult(requestCode, resultCode, data)
     if (requestCode == WEB_VIEW_REQUEST_CODE) {
       if (resultCode == WebViewActivity.FAIL) {
-        sendPayPalConfirmationEvent("cancel")
+        if(data?.dataString?.contains("codapayments") != true){
+          sendPayPalConfirmationEvent("cancel")
+        }
         showPaymentMethodsView()
       } else if (resultCode == SUCCESS) {
         if (data?.scheme?.contains("adyencheckout") == true) {


### PR DESCRIPTION
**What does this PR do?**

   This PR attemps to fix an issue where canceling certain payment methods in the webview (local payments) would cause the dialog to get stuck in loading. It attempts to fix the issue client side, by listening to a certain redirect URL. As such, it only works in payment methods where they call it. It should work for PayTm (India) and DANA (Indonesia).

**Database changed?**

   No

**How should this be manually tested?**

  Cancel local payments such as PayTm (India) and DANA (Indonesia) in the WebView and it should return to the payments list. It is known that for certain payments it does not work (such as Doku Wallet). Also if possible check if nothing broke in the process.

**What are the relevant tickets?**

  [WAL-39](https://aptoide.atlassian.net/browse/WAL-39)

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass