### PR TITLE
[WAL-80] Removed fingerprint before showing settings

### DIFF
--- a/app/src/main/java/com/asfoundation/wallet/di/AppModule.kt
+++ b/app/src/main/java/com/asfoundation/wallet/di/AppModule.kt
@@ -8,6 +8,7 @@ import android.content.SharedPreferences
 import android.content.pm.PackageManager
 import android.os.Build
 import android.preference.PreferenceManager
+import androidx.biometric.BiometricManager
 import androidx.core.app.NotificationCompat
 import androidx.room.Room
 import com.adyen.checkout.core.api.Environment
@@ -499,4 +500,8 @@ internal class AppModule {
   @Singleton
   @Provides
   fun providesServicesErrorMapper() = ServicesErrorCodeMapper()
+
+  @Singleton
+  @Provides
+  fun providesBiometricManager(context: Context) = BiometricManager.from(context)
 }

--- a/app/src/main/java/com/asfoundation/wallet/di/InteractorModule.kt
+++ b/app/src/main/java/com/asfoundation/wallet/di/InteractorModule.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.content.SharedPreferences
 import android.content.pm.PackageManager
 import android.os.Build
+import androidx.biometric.BiometricManager
 import com.appcoins.wallet.appcoins.rewards.AppcoinsRewards
 import com.appcoins.wallet.bdsbilling.Billing
 import com.appcoins.wallet.bdsbilling.BillingPaymentProofSubmission
@@ -535,9 +536,10 @@ class InteractorModule {
   }
 
   @Provides
-  fun provideFingerprintInteract(context: Context,
+  fun provideFingerprintInteract(biometricManager: BiometricManager,
+                                 packageManager: PackageManager,
                                  preferencesRepositoryType: PreferencesRepositoryType): FingerPrintInteractor {
-    return FingerPrintInteractor(context, preferencesRepositoryType)
+    return FingerPrintInteractor(biometricManager, packageManager, preferencesRepositoryType)
   }
 
 }

--- a/app/src/main/java/com/asfoundation/wallet/ui/AuthenticationPromptActivity.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/AuthenticationPromptActivity.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import androidx.biometric.BiometricPrompt
-import androidx.biometric.BiometricPrompt.PromptInfo
 import androidx.core.content.ContextCompat
 import com.asf.wallet.R
 import dagger.android.AndroidInjection
@@ -98,7 +97,12 @@ class AuthenticationPromptActivity : BaseActivity(), AuthenticationPromptView {
         .commit()
   }
 
-  override fun showPrompt(biometricPrompt: BiometricPrompt, promptInfo: PromptInfo) {
+  override fun showPrompt(biometricPrompt: BiometricPrompt, deviceCredentialsAllowed: Boolean) {
+    val promptInfo = BiometricPrompt.PromptInfo.Builder()
+        .setTitle(getString(R.string.fingerprint_authentication_required_title))
+        .setSubtitle(getString(R.string.fingerprint_authentication_required_body))
+        .setDeviceCredentialAllowed(deviceCredentialsAllowed)
+        .build()
     biometricPrompt.authenticate(promptInfo)
   }
 

--- a/app/src/main/java/com/asfoundation/wallet/ui/AuthenticationPromptPresenter.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/AuthenticationPromptPresenter.kt
@@ -28,11 +28,8 @@ class AuthenticationPromptPresenter(private val view: AuthenticationPromptView,
   }
 
   private fun showBiometricPrompt() {
-    when (fingerprintInteractor.compatibleDevice()) {
-      BiometricManager.BIOMETRIC_SUCCESS -> {
-        view.showPrompt(view.createBiometricPrompt(),
-            fingerprintInteractor.definePromptInformation())
-      }
+    when (fingerprintInteractor.getDeviceCompatibility()) {
+      BiometricManager.BIOMETRIC_SUCCESS -> view.showPrompt(view.createBiometricPrompt(), true)
       BiometricManager.BIOMETRIC_ERROR_NO_HARDWARE -> view.closeSuccess()
       BiometricManager.BIOMETRIC_ERROR_HW_UNAVAILABLE -> view.closeSuccess()
       BiometricManager.BIOMETRIC_ERROR_NONE_ENROLLED -> {

--- a/app/src/main/java/com/asfoundation/wallet/ui/AuthenticationPromptView.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/AuthenticationPromptView.kt
@@ -11,7 +11,7 @@ interface AuthenticationPromptView {
 
   fun showAuthenticationBottomSheet(timer: Long)
 
-  fun showPrompt(biometricPrompt: BiometricPrompt, promptInfo: BiometricPrompt.PromptInfo)
+  fun showPrompt(biometricPrompt: BiometricPrompt, deviceCredentialsAllowed: Boolean)
 
   fun getRetryButtonClick(): Observable<Any>
 

--- a/app/src/main/java/com/asfoundation/wallet/ui/FingerPrintInteractor.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/FingerPrintInteractor.kt
@@ -1,25 +1,22 @@
 package com.asfoundation.wallet.ui
 
-import android.content.Context
+import android.content.pm.PackageManager
+import android.content.pm.PackageManager.FEATURE_FINGERPRINT
+import android.os.Build
 import androidx.biometric.BiometricManager
-import androidx.biometric.BiometricPrompt
-import com.asf.wallet.R
 import com.asfoundation.wallet.repository.PreferencesRepositoryType
 
-class FingerPrintInteractor(private val context: Context,
+class FingerPrintInteractor(private val biometricManager: BiometricManager,
+                            private val packageManager: PackageManager,
                             private val preferencesRepositoryType: PreferencesRepositoryType) {
 
-  fun compatibleDevice(): Int {
-    return BiometricManager.from(context)
-        .canAuthenticate()
-  }
-
-  fun definePromptInformation(): BiometricPrompt.PromptInfo {
-    return BiometricPrompt.PromptInfo.Builder()
-        .setTitle(context.getString(R.string.fingerprint_authentication_required_title))
-        .setSubtitle(context.getString(R.string.fingerprint_authentication_required_body))
-        .setDeviceCredentialAllowed(true)
-        .build()
+  fun getDeviceCompatibility(): Int {
+    val biometricCompatibility = biometricManager.canAuthenticate()
+    //User may have biometrics but no fingerprint (e.g face recognition)
+    if (hasBiometrics(biometricCompatibility) && !hasFingerPrint()) {
+      return BiometricManager.BIOMETRIC_ERROR_NO_HARDWARE
+    }
+    return biometricCompatibility
   }
 
   fun setAuthenticationPermission(value: Boolean) =
@@ -29,4 +26,16 @@ class FingerPrintInteractor(private val context: Context,
 
   fun setAuthenticationErrorTime(currentTime: Long) =
       preferencesRepositoryType.setAuthenticationErrorTime(currentTime)
+
+  private fun hasBiometrics(biometricCompatibility: Int): Boolean {
+    return (biometricCompatibility == BiometricManager.BIOMETRIC_SUCCESS || biometricCompatibility == BiometricManager.BIOMETRIC_ERROR_NONE_ENROLLED)
+  }
+
+  private fun hasFingerPrint(): Boolean {
+    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+      packageManager.hasSystemFeature(FEATURE_FINGERPRINT)
+    } else {
+      false
+    }
+  }
 }

--- a/app/src/main/java/com/asfoundation/wallet/ui/SettingsFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/SettingsFragment.kt
@@ -54,6 +54,7 @@ class SettingsFragment : PreferenceFragmentCompat(), SettingsView {
     presenter =
         SettingsPresenter(this, activityView, Schedulers.io(), AndroidSchedulers.mainThread(),
             CompositeDisposable(), settingsInteract)
+    presenter.setFingerPrintPreference()
   }
 
   override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {

--- a/app/src/main/java/com/asfoundation/wallet/ui/SettingsInteractor.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/SettingsInteractor.kt
@@ -38,7 +38,7 @@ class SettingsInteractor(private val findDefaultWalletInteract: FindDefaultWalle
   fun retrieveUpdateIntent() = autoUpdateInteract.buildUpdateIntent()
 
   fun retrieveFingerPrintAvailability(): Int {
-    fingerPrintAvailability = fingerPrintInteractor.compatibleDevice()
+    fingerPrintAvailability = fingerPrintInteractor.getDeviceCompatibility()
     return fingerPrintAvailability
   }
 

--- a/app/src/main/java/com/asfoundation/wallet/ui/SettingsPresenter.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/SettingsPresenter.kt
@@ -15,7 +15,6 @@ class SettingsPresenter(private val view: SettingsView,
                         private val settingsInteractor: SettingsInteractor) {
 
   fun present() {
-    setFingerPrintPreference()
     handleAuthenticationResult()
     onFingerPrintPreferenceChange()
   }
@@ -42,7 +41,7 @@ class SettingsPresenter(private val view: SettingsView,
     view.setBackupPreference()
   }
 
-  private fun setFingerPrintPreference() {
+  fun setFingerPrintPreference() {
     when (settingsInteractor.retrieveFingerPrintAvailability()) {
       BiometricManager.BIOMETRIC_SUCCESS -> view.setFingerprintPreference(
           settingsInteractor.hasAuthenticationPermission())


### PR DESCRIPTION
**What does this PR do?**

Moves device compatibility to onCreate to avoid showing preference and then hiding it if device doesn't support fingerprint

**Database changed?**

No

**Where should the reviewer start?**

SettingsPresenter.kt

**How should this be manually tested?**

With a device without fingerprint HW, check if the fingerprint settings doesn't appear
Check if the rest of the settings flow isn't affected by this

**What are the relevant tickets?**

https://aptoide.atlassian.net/browse/WAL-80

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new libs, new keys, etc.)




**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass