### PR TITLE
[WAL-94] Card number error icon overlapped by card icon

### DIFF
--- a/app/src/main/java/com/asfoundation/wallet/billing/adyen/AdyenPaymentFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/billing/adyen/AdyenPaymentFragment.kt
@@ -430,6 +430,7 @@ class AdyenPaymentFragment : DaggerFragment(), AdyenPaymentView {
     val height = resources.getDimensionPixelSize(R.dimen.adyen_text_input_layout_height)
 
     adyenCardNumberLayout.minimumHeight = height
+    adyenCardNumberLayout.errorIconDrawable = null
     adyenExpiryDateLayout.minimumHeight = height
     adyenSecurityCodeLayout.minimumHeight = height
   }

--- a/app/src/main/java/com/asfoundation/wallet/topup/TopUpFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/topup/TopUpFragment.kt
@@ -2,7 +2,6 @@ package com.asfoundation.wallet.topup
 
 import android.content.Context
 import android.content.res.Configuration
-import android.content.res.Resources
 import android.os.Bundle
 import android.util.TypedValue
 import android.view.LayoutInflater
@@ -29,6 +28,7 @@ import com.asfoundation.wallet.ui.iab.FiatValue
 import com.asfoundation.wallet.ui.iab.PaymentMethod
 import com.asfoundation.wallet.util.CurrencyFormatUtils
 import com.asfoundation.wallet.util.WalletCurrency
+import com.asfoundation.wallet.util.convertDpToPx
 import com.jakewharton.rxbinding2.view.RxView
 import com.jakewharton.rxbinding2.widget.RxTextView
 import com.jakewharton.rxrelay2.PublishRelay
@@ -98,9 +98,7 @@ class TopUpFragment : DaggerFragment(), TopUpFragmentView {
     fragmentView?.let {
       val heightDiff: Int = it.rootView.height - it.height - appBarHeight
 
-      val threshold = TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 150f,
-          requireContext().resources.displayMetrics)
-          .toInt()
+      val threshold = 150.convertDpToPx(resources)
 
       keyboardEvents.onNext(heightDiff > threshold)
     }
@@ -190,10 +188,10 @@ class TopUpFragment : DaggerFragment(), TopUpFragmentView {
       val orientation = resources.configuration.orientation
       val params: LayoutParams = payment_methods.layoutParams as LayoutParams
       if (orientation == Configuration.ORIENTATION_LANDSCAPE) {
-        params.height = dpToPx(164f)
+        params.height = 164.convertDpToPx(resources)
       }
       if (orientation == Configuration.ORIENTATION_PORTRAIT && paymentMethods.size > 3) {
-        params.height = dpToPx(228f)
+        params.height = 228.convertDpToPx(resources)
       }
       payment_methods.layoutParams = params
     }
@@ -586,22 +584,9 @@ class TopUpFragment : DaggerFragment(), TopUpFragmentView {
     }
   }
 
-  private fun dpToPx(value: Float) = TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, value,
-      Resources.getSystem().displayMetrics)
-      .toInt()
-
   private fun getTopUpValuesSpanCount(): Int {
-    val screenWidth =
-        TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_PX,
-            fragmentContainer.measuredWidth.toFloat(),
-            requireContext().resources
-                .displayMetrics)
-            .toInt()
-
-    val viewWidth = TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 80f,
-        requireContext().resources
-            .displayMetrics)
-        .toInt()
+    val screenWidth = fragmentContainer.measuredWidth.convertDpToPx(resources)
+    val viewWidth = 80.convertDpToPx(resources)
 
     return screenWidth / viewWidth
   }

--- a/app/src/main/java/com/asfoundation/wallet/topup/TopUpItemDecorator.kt
+++ b/app/src/main/java/com/asfoundation/wallet/topup/TopUpItemDecorator.kt
@@ -1,9 +1,9 @@
 package com.asfoundation.wallet.topup
 
 import android.graphics.Rect
-import android.util.TypedValue
 import android.view.View
 import androidx.recyclerview.widget.RecyclerView
+import com.asfoundation.wallet.util.convertDpToPx
 
 
 class TopUpItemDecorator(private val size: Int, private val addMargin: Boolean) :
@@ -15,16 +15,8 @@ class TopUpItemDecorator(private val size: Int, private val addMargin: Boolean) 
       val position: Int = parent.getChildAdapterPosition(view)
       val spanCount = size
 
-      val screenWidth =
-          TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_PX, parent.measuredWidth.toFloat(),
-                  parent.context.resources
-                      .displayMetrics)
-              .toInt()
-
-      val viewWidth = TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 80f,
-              parent.context.resources
-                  .displayMetrics)
-          .toInt()
+      val screenWidth = parent.measuredWidth.convertDpToPx(parent.context.resources)
+      val viewWidth = 80.convertDpToPx(parent.context.resources)
 
       val spacing = (((screenWidth - viewWidth * spanCount) / (spanCount + 1)) * 0.99).toInt()
 

--- a/app/src/main/java/com/asfoundation/wallet/topup/payment/AdyenTopUpFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/topup/payment/AdyenTopUpFragment.kt
@@ -499,6 +499,7 @@ class AdyenTopUpFragment : DaggerFragment(), AdyenTopUpView {
     view.setPadding(0, 0, 24, 0)
 
     adyenCardNumberLayout.minimumHeight = height
+    adyenCardNumberLayout.errorIconDrawable = null
     adyenExpiryDateLayout.minimumHeight = height
     adyenSecurityCodeLayout.minimumHeight = height
   }

--- a/app/src/main/java/com/asfoundation/wallet/ui/appcoins/CardNotificationsItemDecorator.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/appcoins/CardNotificationsItemDecorator.kt
@@ -1,9 +1,9 @@
 package com.asfoundation.wallet.ui.appcoins
 
 import android.graphics.Rect
-import android.util.TypedValue
 import android.view.View
 import androidx.recyclerview.widget.RecyclerView
+import com.asfoundation.wallet.util.convertDpToPx
 import kotlin.math.max
 
 
@@ -35,21 +35,11 @@ class CardNotificationsItemDecorator : RecyclerView.ItemDecoration() {
       outRect.right = 16
       outRect.left = 16
 
-      val maxWidth = TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 400f,
-          parent.context.resources
-              .displayMetrics)
-          .toInt()
+      val maxWidth = 400.convertDpToPx(parent.context.resources)
 
-      val margins = TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 32f,
-          parent.context.resources
-              .displayMetrics)
-          .toInt()
+      val margins = 32.convertDpToPx(parent.context.resources)
 
-      val screenWidth =
-          TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_PX, parent.measuredWidth.toFloat(),
-              parent.context.resources
-                  .displayMetrics)
-              .toInt()
+      val screenWidth = parent.measuredWidth.convertDpToPx(parent.context.resources)
 
       val cardWidth = if (screenWidth > maxWidth) {
         maxWidth

--- a/app/src/main/java/com/asfoundation/wallet/ui/balance/BalanceFragment.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/balance/BalanceFragment.kt
@@ -5,9 +5,7 @@ import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.Context
 import android.content.Intent
-import android.content.res.Resources
 import android.os.Bundle
-import android.util.TypedValue
 import android.view.KeyEvent
 import android.view.LayoutInflater
 import android.view.View
@@ -20,6 +18,7 @@ import com.asfoundation.wallet.ui.MyAddressActivity
 import com.asfoundation.wallet.ui.wallets.WalletsFragment
 import com.asfoundation.wallet.util.CurrencyFormatUtils
 import com.asfoundation.wallet.util.WalletCurrency
+import com.asfoundation.wallet.util.convertDpToPx
 import com.asfoundation.wallet.viewmodel.BasePageViewFragment
 import com.asfoundation.wallet.wallet_validation.generic.WalletValidationActivity
 import com.google.android.material.appbar.AppBarLayout
@@ -122,7 +121,7 @@ class BalanceFragment : BasePageViewFragment(), BalanceFragmentView {
     popup = PopupWindow(tooltip)
     popup?.height = ViewGroup.LayoutParams.WRAP_CONTENT
     popup?.width = ViewGroup.LayoutParams.MATCH_PARENT
-    val offset = dpToPx(25f)
+    val offset = 25.convertDpToPx(resources)
     faded_background.visibility = View.VISIBLE
     popup?.showAsDropDown(backup_active_button, 0, offset * -1)
   }
@@ -359,8 +358,4 @@ class BalanceFragment : BasePageViewFragment(), BalanceFragmentView {
   private fun setAlpha(view: View, alphaPercentage: Float) {
     view.alpha = 1 - alphaPercentage * 1.20f
   }
-
-  private fun dpToPx(value: Float) = TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, value,
-      Resources.getSystem().displayMetrics)
-      .toInt()
 }

--- a/app/src/main/java/com/asfoundation/wallet/ui/widget/adapter/CardNotificationsAdapter.kt
+++ b/app/src/main/java/com/asfoundation/wallet/ui/widget/adapter/CardNotificationsAdapter.kt
@@ -8,6 +8,7 @@ import com.asf.wallet.R
 import com.asfoundation.wallet.referrals.CardNotification
 import com.asfoundation.wallet.ui.widget.holder.CardNotificationAction
 import com.asfoundation.wallet.ui.widget.holder.CardNotificationViewHolder
+import com.asfoundation.wallet.util.convertDpToPx
 import rx.functions.Action2
 
 class CardNotificationsAdapter(
@@ -22,15 +23,9 @@ class CardNotificationsAdapter(
         .inflate(R.layout.item_card_notification, parent,
             false)
 
-    val maxWith = TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 400f,
-        parent.context.resources
-            .displayMetrics)
-        .toInt()
+    val maxWith = 400.convertDpToPx(parent.context.resources)
 
-    val margins = TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 32f,
-        parent.context.resources
-            .displayMetrics)
-        .toInt()
+    val margins = 32.convertDpToPx(parent.context.resources)
 
     if (itemCount > 1) {
       val screenWith =

--- a/app/src/main/java/com/asfoundation/wallet/util/ExtensionFunctionUtils.kt
+++ b/app/src/main/java/com/asfoundation/wallet/util/ExtensionFunctionUtils.kt
@@ -1,11 +1,13 @@
 package com.asfoundation.wallet.util
 
+import android.content.res.Resources
 import android.graphics.Bitmap
 import android.graphics.Canvas
 import android.graphics.Matrix
 import android.graphics.Point
 import android.graphics.drawable.BitmapDrawable
 import android.graphics.drawable.Drawable
+import android.util.TypedValue
 import android.view.WindowManager
 import com.google.zxing.BarcodeFormat
 import com.google.zxing.MultiFormatWriter
@@ -85,4 +87,13 @@ inline fun <T> Iterable<T>.sumByBigDecimal(selector: (T) -> BigDecimal): BigDeci
     sum += selector(element)
   }
   return sum
+}
+
+fun Int.convertDpToPx(resources: Resources): Int {
+  return TypedValue.applyDimension(
+      TypedValue.COMPLEX_UNIT_DIP,
+      this.toFloat(),
+      resources.displayMetrics
+  )
+      .toInt()
 }


### PR DESCRIPTION
**What does this PR do?**

Removed error icon since it was being overlapped by the card icon. 
It was first attempted to move the card icon to the left, but in some devices it would overlap the card numbers.
Since in the first attempt I had to convert dp to px, I ended extracting that logic to an extension function.

**Database changed?**

 No

**Where should the reviewer start?**

AdyenTopUpFragment.kt
AdyenPaymentFragment.kt

**How should this be manually tested?**

Check if the icon appears in both topup and iab layouts

**What are the relevant tickets?**

https://aptoide.atlassian.net/browse/WAL-94

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new libs, new keys, etc.)




**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass